### PR TITLE
add req.httpVersion, req.httpVersionMajor, and req.httpVersionMinor

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -124,6 +124,18 @@ module.exports = class Request extends Readable {
         return index !== -1 ? host.slice(0, index) : host;
     }
 
+    get httpVersion() {
+        return '1.1';
+    }
+
+    get httpVersionMajor() {
+        return 1;
+    }
+
+    get httpVersionMinor() {
+        return 1;
+    }
+
     get ip() {
         const trust = this.app.get('trust proxy fn');
         if(!trust) {


### PR DESCRIPTION
adds getters to req for httpVersion, httpVersionMajor, and httpVersionMinor
uws.js has no method to get http version but it only handles 1.1 anyways