### PR TITLE
fix sending buffers

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -250,7 +250,7 @@ module.exports = class Response extends Writable {
                 deprecated('res.send(status)', 'res.sendStatus(status)');
                 return this.sendStatus(body);
             }
-        } else {
+        } else if(!Buffer.isBuffer(body)) {
             body = String(body);
         }
         if(typeof body === 'string') {


### PR DESCRIPTION
res.send(buffer) would add `; charset=utf-8` to the end of the content type, now it checks if its a buffer before turning it into a string 