### PR TITLE
add timeout to tests (async)

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -7,6 +7,7 @@ const fs = require("fs");
 const path = require("path");
 const test = require("node:test");
 const childProcess = require("node:child_process");
+const exec = require("util").promisify(childProcess.exec)
 const assert = require("node:assert");
 
 const testPath = path.join(__dirname, 'tests');
@@ -40,20 +41,28 @@ for (const testCategory of testCategories) {
             }
 
             await new Promise(resolve => {
-                test(testDescription, () => {
-                    process.stdout.write(testDescription + '...');
+                test(testDescription, async () => {
+                    let timeout;
+                    let timeoutFunc = (module) => {
+                        setTimeout(() => process.exit(1));
+                        throw `${module} timed out`;
+                    };
+
                     try {
-                        let expressOutput = childProcess.execSync(`node ${testPath}`).toString();
+                        timeout = setTimeout(() => timeoutFunc('express'), 60000);
+                        let expressOutput = (await exec(`node ${testPath}`)).stdout;
+                        clearTimeout(timeout);
 
                         fs.writeFileSync(testPath, testCode.replace(`const express = require("express");`, `const express = require("../../../src/index.js");`));
-                        let uExpressOutput = childProcess.execSync(`node ${testPath}`).toString();
+                        timeout = setTimeout(() => timeoutFunc('ultimate-express'), 60000)
+                        let uExpressOutput = (await exec(`node ${testPath}`)).stdout;
+                        clearTimeout(timeout);
 
                         assert.strictEqual(uExpressOutput, expressOutput);
-                        console.log('\x1b[32mOK\x1b[0m');
                     } catch (error) {
-                        console.log('\x1b[31mFAIL\x1b[0m');
                         throw error;
                     } finally {
+                        clearTimeout(timeout);
                         fs.writeFileSync(testPath, testCode);
                         resolve();
                     }


### PR DESCRIPTION
now uses promisified `childProcess.exec`, with a timeout of 60 secs
also, for some reason, making it async made it log differently so i removed the `testDescription` and OK/FAIL logging since it does it by itself now (it arguably looks better, i have no idea why it did that though)