### PR TITLE
Listen must return HTTP server

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -229,6 +229,7 @@ class Application extends Router {
         }
         this.listenCalled = true;
         this.uwsApp[fn](...args);
+        return this.uwsApp;
     }
 
     address() {


### PR DESCRIPTION
In vanilla Express the `listen()` method return HTTP server