### PR TITLE
perf: Cache of compiled regex

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -31,6 +31,8 @@ const methods = [
 ];
 const supportedUwsMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD', 'CONNECT', 'TRACE'];
 
+const regExParam = /:(\w+)/g;
+
 module.exports = class Router extends EventEmitter {
     constructor(settings = {}) {
         super();
@@ -264,7 +266,7 @@ module.exports = class Router extends EventEmitter {
             method = 'del';
         }
         if(!route.optimizedRouter && route.path.includes(":")) {
-            route.optimizedParams = route.path.match(/:(\w+)/g).map(p => p.slice(1));
+            route.optimizedParams = route.path.match(regExParam).map(p => p.slice(1));
         }
         const fn = async (res, req) => {
             const { request, response } = this.handleRequest(res, req);
@@ -282,7 +284,7 @@ module.exports = class Router extends EventEmitter {
             }
         };
         route.optimizedPath = optimizedPath;
-        let replacedPath = route.path.replace(/:(\w+)/g, ':x');
+        let replacedPath = route.path.replace(regExParam, ':x');
         this.uwsApp[method](replacedPath, fn);
         if(!this.get('strict routing') && route.path[route.path.length - 1] !== '/') {
             this.uwsApp[method](replacedPath + '/', fn);

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,9 +44,9 @@ function patternToRegex(pattern, isPrefix = false) {
     }
 
     let regexPattern = pattern
-        .replace(/\./g, '\\.')
-        .replace(/\-/g, '\\-')
-        .replace(/\*/g, '(.*)') // Convert * to .*
+        .replaceAll('.', '\\.')
+        .replaceAll('-', '\\-')
+        .replaceAll('*', '(.*)') // Convert * to .*
         .replace(/:(\w+)(\(.+?\))?/g, (match, param, regex) => {
             return `(?<${param}>${regex ? regex + '($|\\/)' : '[^/]+'})`;
         }); // Convert :param to capture group


### PR DESCRIPTION
[cache compilation of regex](https://github.com/dimdenGD/ultimate-express/pull/31/commits/910cc9fb6784ecc81db1238e9f6e447368589d7e) 
Store the compilation of regex into a variable

[better performance with replaceAll](https://github.com/dimdenGD/ultimate-express/pull/31/commits/3e6afe4ff20e3f12892f04f6bb8a8e3e146ae2c1) 
String.prototype.replaceAll has better performance instead of regex