### PR TITLE
perf: don't parse query if query is empty

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,11 @@ const etag = require("etag");
 const { Stats } = require("fs");
 
 function fastQueryParse(query, options) {
-    if(query.length <= 128) {
+    const len = query.length;
+    if(len === 0){
+        return null;
+    }
+    if(len <= 128) {
         if(!query.includes('[') && !query.includes('%5B') && !query.includes('.') && !query.includes('%2E')) {
             return querystring.parse(query);
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,7 +25,7 @@ const { Stats } = require("fs");
 function fastQueryParse(query, options) {
     const len = query.length;
     if(len === 0){
-        return null;
+        return new NullObject();
     }
     if(len <= 128) {
         if(!query.includes('[') && !query.includes('%5B') && !query.includes('.') && !query.includes('%2E')) {


### PR DESCRIPTION
 No need to parse query if the query is empty