### PR TITLE
perf: avoid useless regex into route resolution

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -453,9 +453,9 @@ module.exports = class Router extends EventEmitter {
         // so call it as async when the request has been through every 300 routes to reset it
         const continueRoute = this._paramCallbacks.size === 0 && req.routeCount % 300 !== 0 ? 
             this._preprocessRequest(req, res, route) : await this._preprocessRequest(req, res, route);
-        
+
+        const strictRouting = this.get('strict routing');
         if(route.use) {
-            const strictRouting = this.get('strict routing');
             req._stack.push(route.path);
             req._opPath = req._originalPath.replace(this.getFullMountpath(req), '');
             if(req.endsWithSlash && req._opPath[req._opPath.length - 1] !== '/') {
@@ -472,7 +472,6 @@ module.exports = class Router extends EventEmitter {
                 req.path = '/';
             }
         }
-        const strictRouting = this.get('strict routing');
         return new Promise((resolve) => {
             const next = async (thingamabob) => {
                 if(thingamabob) {

--- a/src/router.js
+++ b/src/router.js
@@ -118,7 +118,9 @@ module.exports = class Router extends EventEmitter {
             }
             return pattern === path;
         }
-        
+        if (pattern.source === '(?:)'){
+            return true;
+        }
         return pattern.test(path);
     }
 
@@ -470,13 +472,14 @@ module.exports = class Router extends EventEmitter {
                 req.path = '/';
             }
         }
+        const strictRouting = this.get('strict routing');
         return new Promise((resolve) => {
             const next = async (thingamabob) => {
                 if(thingamabob) {
                     if(thingamabob === 'route' || thingamabob === 'skipPop') {
                         if(route.use && thingamabob !== 'skipPop') {
                             req._stack.pop();
-                            const strictRouting = this.get('strict routing');
+                            
                             req._opPath = req._stack.length > 0 ? req._originalPath.replace(this.getFullMountpath(req), '') : req._originalPath;
                             if(strictRouting) {
                                 if(req.endsWithSlash && req._opPath[req._opPath.length - 1] !== '/') {

--- a/src/router.js
+++ b/src/router.js
@@ -118,9 +118,7 @@ module.exports = class Router extends EventEmitter {
             }
             return pattern === path;
         }
-        if (pattern.source === '(?:)'){
-            return true;
-        }
+        
         return pattern.test(path);
     }
 
@@ -453,9 +451,9 @@ module.exports = class Router extends EventEmitter {
         // so call it as async when the request has been through every 300 routes to reset it
         const continueRoute = this._paramCallbacks.size === 0 && req.routeCount % 300 !== 0 ? 
             this._preprocessRequest(req, res, route) : await this._preprocessRequest(req, res, route);
-
-        const strictRouting = this.get('strict routing');
+        
         if(route.use) {
+            const strictRouting = this.get('strict routing');
             req._stack.push(route.path);
             req._opPath = req._originalPath.replace(this.getFullMountpath(req), '');
             if(req.endsWithSlash && req._opPath[req._opPath.length - 1] !== '/') {
@@ -478,7 +476,7 @@ module.exports = class Router extends EventEmitter {
                     if(thingamabob === 'route' || thingamabob === 'skipPop') {
                         if(route.use && thingamabob !== 'skipPop') {
                             req._stack.pop();
-                            
+                            const strictRouting = this.get('strict routing');
                             req._opPath = req._stack.length > 0 ? req._originalPath.replace(this.getFullMountpath(req), '') : req._originalPath;
                             if(strictRouting) {
                                 if(req.endsWithSlash && req._opPath[req._opPath.length - 1] !== '/') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -207,7 +207,7 @@ function deprecated(oldMethod, newMethod, full = false) {
 }
 
 function findIndexStartingFrom(arr, fn, index = 0) {
-    for(let i = index; i < arr.length; i++) {
+    for(let i = index, end = arr.length; i < end; i++) {
         if(fn(arr[i], i, arr)) {
             return i;
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,6 +22,8 @@ const querystring = require("fast-querystring");
 const etag = require("etag");
 const { Stats } = require("fs");
 
+const EMPTY_REGEX = new RegExp(``);
+
 function fastQueryParse(query, options) {
     const len = query.length;
     if(len === 0){
@@ -46,7 +48,7 @@ function patternToRegex(pattern, isPrefix = false) {
         return pattern;
     }
     if(isPrefix && pattern === '') {
-        return new RegExp(``);
+        return EMPTY_REGEX;
     }
 
     let regexPattern = pattern


### PR DESCRIPTION
Regex are slower and `(?:)` is always true! no need to test it!