### PR TITLE
perf: simplify req.accepts*

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -313,8 +313,7 @@ module.exports = class Request extends Readable {
     }
 
     acceptsCharsets(...charsets) {
-        const accept = accepts({ headers: this.headers });
-        return accept.charsets(...charsets);
+        return accepts({ headers: this.headers }).charsets(...charsets);
     }
 
     acceptsEncodings(...encodings) {
@@ -322,8 +321,7 @@ module.exports = class Request extends Readable {
     }
     
     acceptsLanguages(...languages) {
-        const accept = accepts({ headers: this.headers });
-        return accept.languages(...languages);
+        return accepts({ headers: this.headers }).languages(...languages);
     }
 
     is(type) {

--- a/src/request.js
+++ b/src/request.js
@@ -308,20 +308,19 @@ module.exports = class Request extends Readable {
     }
 
     accepts(...types) {
-        const accept = accepts({ headers: this.headers });
-        return accept.types(...types);
+        return accepts(this).types(...types);
     }
 
     acceptsCharsets(...charsets) {
-        return accepts({ headers: this.headers }).charsets(...charsets);
+        return accepts(this).charsets(...charsets);
     }
 
     acceptsEncodings(...encodings) {
-        return accepts({ headers: this.headers }).encodings(...encodings);
+        return accepts(this).encodings(...encodings);
     }
     
     acceptsLanguages(...languages) {
-        return accepts({ headers: this.headers }).languages(...languages);
+        return accepts(this).languages(...languages);
     }
 
     is(type) {

--- a/src/request.js
+++ b/src/request.js
@@ -318,8 +318,7 @@ module.exports = class Request extends Readable {
     }
 
     acceptsEncodings(...encodings) {
-        const accept = accepts({ headers: this.headers });
-        return accept.encodings(...encodings);
+        return accepts({ headers: this.headers }).encodings(...encodings);
     }
     
     acceptsLanguages(...languages) {


### PR DESCRIPTION
- No need to declare a new variable `const accept = accepts({ headers: this.headers });` https://github.com/dimdenGD/ultimate-express/pull/56/commits/e8bb956a85535c2580a19acdcb0b9697c071909e
- No need to create a `object accepts({ headers: this.headers })` https://github.com/dimdenGD/ultimate-express/pull/56/commits/6ff51e6b4d54f685845317873b9f30b3396e80c6

**Bonus Improvements**:
- Maybe we can also cache `accepts(this)` initialization, see https://github.com/dimdenGD/ultimate-express/pull/56#issuecomment-2480818321