### PR TITLE
feat: add nest adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ultimate-express",
-  "version": "1.3.15",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ultimate-express",
-      "version": "1.3.15",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/express": "^4.0.0",
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@codechecks/client": "^0.1.12",
+        "@nestjs/platform-express": "^10.4.13",
         "body-parser": "^1.20.3",
         "compression": "^1.7.5",
         "cookie-parser": "^1.4.6",
@@ -317,6 +318,157 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@nestjs/common": {
+      "version": "10.4.13",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.13.tgz",
+      "integrity": "sha512-NVJ2UYMRdMkxCcwmoWP8xihpUyd1uqKR+7QqTF3m8aedufpZm8W6WbUmNkD1j/o9TxRzhKW43PemeSMigZj+Bw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "iterare": "1.2.1",
+        "tslib": "2.8.1",
+        "uid": "2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/core": {
+      "version": "10.4.13",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.13.tgz",
+      "integrity": "sha512-zivGEaq9tmwdeQi/RK0nUVdvhdIwcIsytBvEGTmDBFkmEnxEMp3T0Ia4BTFlTFrjLAb5D2cNUQZBZZj1vqfXtw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nuxtjs/opencollective": "0.3.2",
+        "fast-safe-stringify": "2.1.1",
+        "iterare": "1.2.1",
+        "path-to-regexp": "3.3.0",
+        "tslib": "2.8.1",
+        "uid": "2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/microservices": "^10.0.0",
+        "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/websockets": "^10.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/platform-express": {
+          "optional": true
+        },
+        "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/core/node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@nestjs/platform-express": {
+      "version": "10.4.13",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.13.tgz",
+      "integrity": "sha512-9Uar9t5NZebI9Y8P8B6OYTfj6p5DuUHM/nk2zGwbL3SLdnieP4O2K1DuePo3SWiYBStmPoTAlXyl6L2zDtrLjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "body-parser": "1.20.3",
+        "cors": "2.8.5",
+        "express": "4.21.1",
+        "multer": "1.4.4-lts.1",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0"
+      }
+    },
+    "node_modules/@nestjs/platform-express/node_modules/multer": {
+      "version": "1.4.4-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.4-lts.1.tgz",
+      "integrity": "sha512-WeSGziVj6+Z2/MwQo3GvqzgR+9Uc+qt8SwHKh3gvNPiISKfsMfG4SvCOFYlxxgkXt7yIV2i1yczehm0EOKIxIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/opencollective": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/opencollective/-/opencollective-0.3.2.tgz",
+      "integrity": "sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "consola": "^2.15.0",
+        "node-fetch": "^2.6.1"
+      },
+      "bin": {
+        "opencollective": "bin/opencollective.js"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
       }
     },
     "node_modules/@octokit/action": {
@@ -1316,6 +1468,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/consola": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/constantinople": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
@@ -2155,6 +2315,14 @@
         "fast-decode-uri-component": "^1.0.1"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fast-zlib": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-zlib/-/fast-zlib-2.0.1.tgz",
@@ -2814,6 +2982,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/iterare": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
+      "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
@@ -3373,6 +3552,28 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/npm-run-path": {
@@ -4005,6 +4206,14 @@
         "esprima": "~4.0.0"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -4124,6 +4333,17 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -4786,6 +5006,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ts-essentials": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.4.tgz",
@@ -4823,6 +5051,13 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tseep/-/tseep-1.3.1.tgz",
       "integrity": "sha512-ZPtfk1tQnZVyr7BPtbJ93qaAh2lZuIOpTMjhrYa4XctT8xe7t4SAW9LIxrySDuYMsfNNayE51E/WNGrNVgVicQ=="
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -4960,6 +5195,20 @@
       "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@lukeed/csprng": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/uid-safe": {
       "version": "2.1.5",
@@ -5125,6 +5374,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ultimate-express",
-  "version": "1.3.17",
+  "version": "1.4.0",
   "description": "The Ultimate Express. Fastest http server with full Express compatibility, based on uWebSockets.",
   "main": "src/index.js",
   "scripts": {
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@codechecks/client": "^0.1.12",
+    "@nestjs/platform-express": "^10.4.13",
     "body-parser": "^1.20.3",
     "compression": "^1.7.5",
     "cookie-parser": "^1.4.6",

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const Router = require("./router.js");
 const middlewares = require("./middlewares.js");
 const Request = require("./request.js");
 const Response = require("./response.js");
+const NestExpressAdapter = require("./nest-adapter.js");
 
 try {
     // disable Uwebsockets header
@@ -50,5 +51,7 @@ Application.json = middlewares.json;
 Application.urlencoded = middlewares.urlencoded;
 Application.text = middlewares.text;
 Application.raw = middlewares.raw;
+
+Application.NestExpressAdapter = NestExpressAdapter;
 
 module.exports = Application;

--- a/src/nest-adapter.js
+++ b/src/nest-adapter.js
@@ -1,0 +1,61 @@
+const { ExpressAdapter } = require("@nestjs/platform-express");
+const Application = require("./application.js");
+
+const getParserOptions = (rawBody, options) => ({
+  ...options,
+  ...(rawBody && {
+    verify: (req, _, buff) => {
+      if (Buffer.isBuffer(buff)) {
+        req.rawBody = buff;
+      }
+      return true;
+    },
+  }),
+});
+
+module.exports = class extends ExpressAdapter {
+  constructor(instance) {
+    super(instance || Application());
+  }
+
+  registerParserMiddleware(_, rawBody) {
+    const jsonOptions = getParserOptions(!!rawBody);
+    const urlencodedOptions = getParserOptions(!!rawBody, { extended: true });
+
+    const parserMiddleware = {
+      jsonParser: Application.json(jsonOptions),
+      urlencodedParser: Application.urlencoded(urlencodedOptions),
+    };
+
+    Object.keys(parserMiddleware)
+      .filter((parser) => !this.#isMiddlewareApplied(parser))
+      .forEach((parserKey) => this.use(parserMiddleware[parserKey]));
+  }
+
+  useBodyParser(type, rawBody, options) {
+    const parserOptions = getParserOptions(rawBody, options);
+    const parser = Application[type](parserOptions);
+
+    this.use(parser);
+
+    return this;
+  }
+
+  initHttpServer(options) {
+    super.initHttpServer(options);
+    this.httpServer = this.getInstance();
+  }
+
+  #isMiddlewareApplied(name) {
+    const app = this.getInstance();
+
+    return (
+      !!app._router &&
+      !!app._router.stack &&
+      typeof app._router.stack.filter === "function" &&
+      app._router.stack.some(
+        (layer) => layer?.handle && layer.handle.name === name,
+      )
+    );
+  }
+};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,7 @@
 declare module "ultimate-express" {
   import e from "@types/express";
   import { AppOptions } from "uWebSockets.js";
+  import NestPlatform from "@nestjs/platform-express";
 
   type Settings = {
     uwsOptions?: AppOptions;
@@ -41,6 +42,9 @@ declare module "ultimate-express" {
     export import Response = e.Response;
     export import Router = e.Router;
     export import Send = e.Send;
+
+    export import NestExpressAdapter = NestPlatform.ExpressAdapter;
+    export import NestExpressApplication = NestPlatform.NestExpressApplication;
   }
 
   function express(settings?: Settings): e.Express;


### PR DESCRIPTION
_PoC:_ Adds support for nest js express adapter.

---

It just overrides some methods of the original `@nestjs/platform-express`.
The question is whether it should be published as separate packages or kept within `ultimate-express`...