### PR TITLE
feat: add support for redirecting trailing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Optimized routes can be up to 10 times faster than normal routes, as they're usi
 
 5. By default, µExpress creates 1 (or 0 if your CPU has only 1 core) child thread to improve performance of reading files. You can change this number by setting `threads` to a different number in `express()`, or set to 0 to disable thread pool (`express({ threads: 0 })`). Threads are shared between all express() instances, with largest `threads` number being used. Using more threads will not necessarily improve performance. Sometimes not using threads at all is faster, please [test](https://github.com/wg/wrk/) both options.
 
+6. Express treats URLs with and without a trailing slash as the same route, while µExpress considers them as two distinct route. If you want to standardize the behavior in µExpress, you can enable redirection of URLs with a trailing slash to their version without a trailing slash using `redirect trailing slash`
+
 ## WebSockets
 
 Since you don't create http server manually, you can't properly use http.on("upgrade") to handle WebSockets. To solve this, there's currently 2 options:

--- a/src/application.js
+++ b/src/application.js
@@ -178,6 +178,14 @@ class Application extends Router {
 
     #createRequestHandler() {
         this.uwsApp.any('/*', async (res, req) => {
+
+            // redirect to non-trailing slash url
+            if(this.settings['redirect trailing slash']) {
+                const path = req.getUrl()
+                const query = req.getQuery()
+                if(path.endsWith('/') && path != '/') return res.writeStatus('301').writeHeader('Location',`${path.slice(0,-1)}${query?'?'+query:''}`).end()
+            }
+
             const { request, response } = this.handleRequest(res, req);
 
             const matchedRoute = await this._routeRequest(request, response);

--- a/tests/tests/res/res-trailing-slashes.js
+++ b/tests/tests/res/res-trailing-slashes.js
@@ -1,0 +1,23 @@
+// must support redirect trailing slash
+
+const express = require("express");
+
+const app = express();
+
+app.enable('redirect trailing slash');
+
+app.get('/test', (req, res) => {
+    res.send('test');
+});
+
+app.listen(13333, async () => {
+    console.log('Server is running on port 13333');
+
+    const response = await Promise.all([
+        fetch('http://localhost:13333/test').then(res => res.text()),
+        fetch('http://localhost:13333/test/', { redirect: 'follow'}).then(res => res.text())
+    ]);
+
+    console.log(response);
+    process.exit(0);
+});


### PR DESCRIPTION
Express treats URLs with and without a trailing slash as the same route, while µExpress considers them as two distinct route. If you want to standardize the behavior in µExpress, you can enable redirection of URLs with a trailing slash to their version without a trailing slash using `redirect trailing slash`

also close https://github.com/dimdenGD/ultimate-express/issues/87