### PR TITLE
fix: use "," instead of ";" as separator of multiple cookie

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -543,7 +543,7 @@ module.exports = class Response extends Writable {
         } else {
             field = field.toLowerCase();
             if(field === 'set-cookie' && Array.isArray(value)) {
-                value = value.join('; ');
+                value = value.join(', ');
             } else if(field === 'content-type') {
                 if(!value.includes('charset=') && (value.startsWith('text/') || value === 'application/json' || value === 'application/javascript')) {
                     value += '; charset=utf-8';


### PR DESCRIPTION
fix https://github.com/dimdenGD/ultimate-express/issues/106

from https://www.rfc-editor.org/rfc/rfc2109

> the Set-Cookie response header comprises the token Set-Cookie:, followed by a comma-separated list of one or more cookies.