### PR TITLE
feat: test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 tmp/
 processed.txt
 /.idea/
+/.nyc_output
+/coverage

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,15 @@
+{
+    "all": true,
+    "check-coverage": false,
+    "extension": [
+        ".js"
+    ],
+    "include": [
+        "src/*"
+    ],
+    "reporter": [
+        "text",
+        "lcov",
+        "html"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.js",
   "scripts": {
     "test": "node tests/index.js",
-    "dev": "node --inspect=9229 demo/index.js"
+    "dev": "node --inspect=9229 demo/index.js",
+    "test:coverage": "nyc node tests/index.js && nyc report --reporter html"
   },
   "engines": {
     "node": ">=18"
@@ -86,6 +87,7 @@
     "method-override": "^3.0.0",
     "multer": "^1.4.5-lts.1",
     "mustache-express": "^1.3.2",
+    "nyc": "^17.1.0",
     "pako": "^2.1.0",
     "pkg-pr-new": "^0.0.29",
     "pug": "^3.0.3",


### PR DESCRIPTION
This PR introduce the test coverage.

With
```
npm run test:coverage
```

after the test, will generate the coverage in the console output:
```
----------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
File            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
All files       |    67.6 |    61.17 |   70.04 |   67.91 |                                                                                                                                                                                                                
 application.js |   78.88 |       57 |   94.73 |   78.65 | 38,59,61-64,66,103,118-121,124-131,137,144,149-153,158,211-212,227-228,242,258,269-270,273,304-310,321                                                                                                         
 declarative.js |    56.5 |     51.2 |   70.58 |   55.36 | 12,29,47,54,61-87,100,120,126,152,177,210,214,217-315,337,350-353,359,385-386,407,410                                                                                                                          
 index.js       |      92 |        0 |   66.66 |      92 | 34-35                                                                                                                                                                                                          
 request.js     |   74.29 |     62.2 |   57.14 |   74.39 | 51,125-126,134-143,160-186,195-201,206,212,242,245-249,254,265,276,298,315-348,367,384                                                                                                                         
 response.js    |   59.47 |    52.92 |   64.91 |   60.72 | ...290,308,311-312,337-338,344-345,352-353,356-357,360-361,366-367,374,379-388,400-401,423,436-437,445-465,472,484,489,497-498,505-533,537,584,596-597,600,644-658,670-696,703-718,736-740,747,762-765,767-795 
 router.js      |   86.11 |    84.59 |   83.78 |   85.63 | 58-59,62-63,91-92,113,118,124-125,141,144,179,216,266-270,279,281,343-347,360,388-389,408-409,429-430,433-436,477,497,510,526,532,550,566,595-604                                                              
 utils.js       |      50 |    50.37 |   67.74 |   50.34 | 48,67,70,87,90,109-142,153-162,187-205,240,258-287,301-303,310-311,328-341                                                                                                                                     
 view.js        |   58.18 |    53.33 |   57.14 |   59.25 | 30,49,68-81,101-125                                                                                                                                                                                            
 worker.js      |       0 |        0 |       0 |       0 | 17-27                                                                                                                                                                                                          
----------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

and an HTML report into "coverage" folder:

![image](https://github.com/user-attachments/assets/36454dcf-e939-49f5-aa2c-61ae0df6a49e)

![image](https://github.com/user-attachments/assets/02f2a42d-bbfe-4a75-b57d-0088e6f9ad21)


This can help to find new test to do!

Some missing area:
 - x-forwarded-host
 - x-forwarded-proto
 - accepts / acceptsCharsets / acceptsEncodings / acceptsLanguages
 - accept-ranges
 - jsonp
 - redirect