### PR TITLE
refactor: remove unnecessary RegExp check in patternToRegex function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -44,9 +44,6 @@ function removeDuplicateSlashes(path) {
 }
 
 function patternToRegex(pattern, isPrefix = false) {
-    if(pattern instanceof RegExp) {
-        return pattern;
-    }
     if(isPrefix && pattern === '') {
         return EMPTY_REGEX;
     }


### PR DESCRIPTION
From coverage seem we can remove pattern check, it's never used

![image](https://github.com/user-attachments/assets/fc8176c7-1eaa-4d5e-b2f9-293136e3d183)

Also `instanceof` is a bit slower!

```js
let x;
console.time('a'); 
x instanceof RegExp; 
console.timeEnd('a');
```
```
a: 0.02392578125 ms
```
