### PR TITLE
chore: invoke function immediately after the current operation completes

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -181,7 +181,7 @@ module.exports = class Router extends EventEmitter {
                         optimizedPathToRouter = optimizedPathToRouter.slice(0, -1); // remove last element, which is the router itself
                         if(optimizedPathToRouter) {
                             // wait for routes in router to be registered
-                            setTimeout(() => {
+                            process.nextTick(() => {
                                 if(!this.listenCalled) {
                                     return; // can only optimize router whos parent is listening
                                 }
@@ -208,7 +208,7 @@ module.exports = class Router extends EventEmitter {
                                         }
                                     }
                                 }
-                            }, 100);
+                            });
                         }
                         // only 1 router can be optimized per route
                         break;


### PR DESCRIPTION
I think waiting 100 milliseconds is excessive, just schedule the function to run at the next cycle of the event loop.

This make ultimate-express a bit faster at startup (-100 ms), 

Also the tests become faster, on my PC all the test run in:

master
```
duration_ms 132895.9447
```

PR
```
duration_ms 125295.7462
```

diff 8 sec

No test added because I think the current tests cover this change