### PR TITLE
chore(typescript): update express type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/express": "^4.0.0",
+        "@types/express": "^4.17.21",
         "accepts": "^1.3.8",
         "acorn": "^8.14.1",
         "bytes": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/dimdenGD/ultimate-express#readme",
   "dependencies": {
-    "@types/express": "^4.0.0",
+    "@types/express": "^4.17.21",
     "accepts": "^1.3.8",
     "acorn": "^8.14.1",
     "bytes": "^3.1.2",


### PR DESCRIPTION
update `@types/express` to 4.17.21 (latest for version 4)

maybe also fix https://github.com/dimdenGD/ultimate-express/issues/72 but need feedback from user