### PR TITLE
debug: test

### DIFF
--- a/tests/tests/errors/async-error-handling.js
+++ b/tests/tests/errors/async-error-handling.js
@@ -7,11 +7,16 @@ const app = express();
 app.set('env', 'production');
 app.set('catch async errors', true);
 
-app.get('/test', async (req, res) => {
+const router = express.Router();
+router.get('/test', async (req, res) => {
     await new Promise((resolve, reject) => {
         reject(new Error('Ignore this error, its used in a test'));
     });
 });
+
+// app.use(router); // works
+// app.use(...[router]); // works
+app.use([router]); // not working
 
 app.listen(13333, async () => {
     console.log('Server is running on port 13333');


### PR DESCRIPTION
```
jimmy:~/Projects/thirdparty/ultimate-express  test-use-router:a24317f $ npm test errors

> ultimate-express@1.4.6 test
> node tests/index.js errors

▶ errors
  ✖ async error handling (174.667793ms)
  ✔ must support custom error handler (255.75272ms)
  ✔ must support next() in error handler (247.151312ms)
  ✔ must support error handler as second callback in use() (208.380907ms)
  ✔ error handling middleware inside router (149.703413ms)
  ✔ error handling middleware (146.484913ms)
  ✔ error status code (154.109673ms)
  ✔ must support multiple error handlers (231.755058ms)
  ✔ support optimized next(err) (161.668361ms)
  ✔ support next(err) (162.283836ms)
  ✔ unexpected error handling (154.367332ms)
  ✔ unexpected error handling inside router (160.098318ms)
✖ errors (2209.562848ms)
ℹ tests 13
ℹ suites 0
ℹ pass 11
ℹ fail 2
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 2212.008058

✖ failing tests:

test at tests/index.js:43:17
✖ async error handling (174.667793ms)
  Error: Command failed: node /home/jimmy/Projects/thirdparty/ultimate-express/tests/tests/errors/async-error-handling.js
  /home/jimmy/Projects/thirdparty/ultimate-express/tests/tests/errors/async-error-handling.js:13
          reject(new Error('Ignore this error, its used in a test'));
                 ^
  
  Error: Ignore this error, its used in a test
      at /home/jimmy/Projects/thirdparty/ultimate-express/tests/tests/errors/async-error-handling.js:13:16
      at new Promise (<anonymous>)
      at /home/jimmy/Projects/thirdparty/ultimate-express/tests/tests/errors/async-error-handling.js:12:11
      at next (/home/jimmy/Projects/thirdparty/ultimate-express/src/router.js:546:37)
      at /home/jimmy/Projects/thirdparty/ultimate-express/src/router.js:569:17
      at new Promise (<anonymous>)
      at Function._routeRequest (/home/jimmy/Projects/thirdparty/ultimate-express/src/router.js:481:16)
      at async next (/home/jimmy/Projects/thirdparty/ultimate-express/src/router.js:528:36)
  
  Node.js v22.15.0
  
      at genericNodeError (node:internal/errors:983:15)
      at wrappedFn (node:internal/errors:537:14)
      at ChildProcess.exithandler (node:child_process:414:12)
      at ChildProcess.emit (node:events:518:28)
      at maybeClose (node:internal/child_process:1101:16)
      at ChildProcess._handle.onexit (node:internal/child_process:304:5) {
    code: 1,
    killed: false,
    signal: null,
    cmd: 'node /home/jimmy/Projects/thirdparty/ultimate-express/tests/tests/errors/async-error-handling.js',
    stdout: 'Server is running on port 13333\n',
    stderr: "/home/jimmy/Projects/thirdparty/ultimate-express/tests/tests/errors/async-error-handling.js:13\n        reject(new Error('Ignore this error, its used in a test'));\n               ^\n\nError: Ignore this error, its used in a test\n    at /home/jimmy/Projects/thirdparty/ultimate-express/tests/tests/errors/async-error-handling.js:13:16\n    at new Promise (<anonymous>)\n    at /home/jimmy/Projects/thirdparty/ultimate-express/tests/tests/errors/async-error-handling.js:12:11\n    at next (/home/jimmy/Projects/thirdparty/ultimate-express/src/router.js:546:37)\n    at /home/jimmy/Projects/thirdparty/ultimate-express/src/router.js:569:17\n    at new Promise (<anonymous>)\n    at Function._routeRequest (/home/jimmy/Projects/thirdparty/ultimate-express/src/router.js:481:16)\n    at async next (/home/jimmy/Projects/thirdparty/ultimate-express/src/router.js:528:36)\n\nNode.js v22.15.0\n"
  }
```