### PR TITLE
chore: add test res.socket

### DIFF
--- a/tests/tests/res/res-socket.js
+++ b/tests/tests/res/res-socket.js
@@ -1,0 +1,18 @@
+// must support res.socket
+
+const express = require("express");
+
+const app = express();
+
+app.get('/test', (req, res) => {
+    console.log(res.socket.writable);
+    res.end();
+});
+
+app.listen(13333, async () => {
+    console.log('Server is running on port 13333');
+
+    const response = await fetch('http://localhost:13333/test').then(res => res.text());
+    console.log(response);
+    process.exit(0);
+});


### PR DESCRIPTION
Original test is
```js
app.get('/test', (req, res) => {
    console.log(res.socket.writable); // expected true
    res.end();
    console.log(res.socket.writable); // expected false
});
```

it works on ultimate-express (`true` `false`), on express is: `true` `true`

this test just check socket property is defined.

I don't know if the correct behaviour is `true` `true` (express)