### PR TITLE
chore(test): error response was already sent

### DIFF
--- a/tests/tests/res/errors.js
+++ b/tests/tests/res/errors.js
@@ -1,0 +1,27 @@
+// must support res error response was already sent
+
+const express = require("express");
+
+const app = express();
+
+app.set("declarative responses", false);
+
+app.get("/test", (req, res) => {
+  res.send("Hello World");
+  res.send("Hello World"); // Response was already sent!
+});
+
+app.use((err, req, res, next) => {
+  console.log(typeof err?.message === "string"); // just check if there is an error
+});
+
+app.listen(13333, async () => {
+  console.log("Server is running on port 13333");
+
+  const responses = await fetch("http://localhost:13333/test").then((res) =>
+    res.text()
+  );
+
+  console.log(responses);
+  process.exit(0);
+});


### PR DESCRIPTION
close https://github.com/dimdenGD/ultimate-express/issues/166

Side notes:

1) with declarative response the behaviour is 
```
Server is running on port 13333
Hello WorldHello World
```

2) I don't check the error string because isn't the same equal message

