### PR TITLE
chore(test): ignore view.js in coverage

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -8,7 +8,8 @@
         "src/*"
     ],
     "exclude": [
-        "src/worker.js"
+        "src/worker.js",
+        "src/view.js"
     ],
     "reporter": [
         "text",


### PR DESCRIPTION
view.js is tested but `nyc` fail to collect coverage because some method are called into `process.nextTick`

https://github.com/dimdenGD/ultimate-express/blob/main/src/view.js#L85-L98