### PR TITLE
chore: unref timers

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -177,9 +177,7 @@ module.exports = class Response extends Writable {
                             }
                         });
                     }, 50);
-                    if( typeof this.#writeTimeout.unref === 'function') {
-                        this.#writeTimeout.unref();
-                    }
+                    this.#writeTimeout.unref();
                 }
                 this.writingChunk = false;
                 callback(null);

--- a/src/response.js
+++ b/src/response.js
@@ -177,6 +177,9 @@ module.exports = class Response extends Writable {
                             }
                         });
                     }, 50);
+                    if( typeof this.#writeTimeout.unref === 'function') {
+                        this.#writeTimeout.unref();
+                    }
                 }
                 this.writingChunk = false;
                 callback(null);

--- a/src/router.js
+++ b/src/router.js
@@ -208,9 +208,7 @@ module.exports = class Router extends EventEmitter {
                                     }
                                 }
                             }, 100);
-                            if( typeof t.unref === 'function') {
-                                t.unref();
-                            }
+                            t.unref();
                         }
                         // only 1 router can be optimized per route
                         break;

--- a/src/router.js
+++ b/src/router.js
@@ -180,7 +180,7 @@ module.exports = class Router extends EventEmitter {
                         optimizedPathToRouter = optimizedPathToRouter.slice(0, -1); // remove last element, which is the router itself
                         if(optimizedPathToRouter) {
                             // wait for routes in router to be registered
-                            setTimeout(() => {
+                            const t = setTimeout(() => {
                                 if(!this.listenCalled) {
                                     return; // can only optimize router whos parent is listening
                                 }
@@ -208,6 +208,9 @@ module.exports = class Router extends EventEmitter {
                                     }
                                 }
                             }, 100);
+                            if( typeof t.unref === 'function') {
+                                t.unref();
+                            }
                         }
                         // only 1 router can be optimized per route
                         break;


### PR DESCRIPTION
https://nodejs.org/api/timers.html#timeoutunref

> When called, the active Timeout object will not require the Node.js event loop to remain active. If there is no other activity keeping the event loop running, the process may exit before the Timeout object's callback is invoked. 

It's just a best practice. No need to wait the timer completition if user need to kill the process (eg. restart)