### PR TITLE
Draft: imp(response): backpressure timeout cleanup

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -39,6 +39,7 @@ const outgoingMessage = new http.OutgoingMessage();
 const symbols = Object.getOwnPropertySymbols(outgoingMessage);
 const kOutHeaders = symbols.find(s => s.toString() === 'Symbol(kOutHeaders)');
 const HIGH_WATERMARK = 256 * 1024;
+const MAX_BUNCH_SIZE = HIGH_WATERMARK / 16384;
 
 class Socket extends EventEmitter {
     constructor(response) {
@@ -150,7 +151,7 @@ module.exports = class Response extends Writable {
     
             if (this.chunkedTransfer) {
                 this.#pendingChunks.push(chunk);
-                if (chunk.length !== 16384) {
+                if (chunk.length !== 16384 || this.#pendingChunks.length === MAX_BUNCH_SIZE) {
                     this._res.write(Buffer.concat(this.#pendingChunks));
                     this.#pendingChunks = [];
                 }

--- a/src/response.js
+++ b/src/response.js
@@ -153,7 +153,7 @@ module.exports = class Response extends Writable {
             if (this.chunkedTransfer) {
                 this.#pendingChunks.push(chunk);
                 clearTimeout(this.#writeTimeout);
-                // Write chunks if not equal to 16382 bytes or the max bunch size has been reached
+                // Write chunks if not equal to 16384 bytes or the max bunch size has been reached
                 if (chunk.length !== 16384 || this.#pendingChunks.length === MAX_BUNCH_SIZE) {
                     this._res.write(Buffer.concat(this.#pendingChunks));
                     this.#pendingChunks = [];


### PR DESCRIPTION
Hey @dimdenGD and @nigrosimone I came with an idea and it's based on the current implementation - hope it works for you too.

I removed the timeout and shrinked it to the bare minimum. The logic is quite simple, while writing, check if it's an near 100% chunk (length of 16384). If so, only push and "wait" until the next chunk is smaller than 16384 which marks the end and ready to flush.

The streams are having a highWaterMark, and thats the upper limit for the next write which means we always have a bunch of concated chunks of max highWaterMark of stream.

In the case it is exactly 16384 and nothing more, thats not a problem because the "end" flush the rest anyway.

You could even do somthing like this and it works...
```javascript
this.#pendingChunks.push(chunk);
---> if (false) {
            this._res.write(Buffer.concat(this.#pendingChunks));
            this.#pendingChunks = [];
        }
this.writingChunk = false;
callback(null);
```

but that would mean "end" would have to flush everything and that wouldn't be good.