### PR TITLE
fix(timestamp): use performance.now()

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -153,7 +153,7 @@ module.exports = class Response extends Writable {
             if (this.chunkedTransfer) {
                 this.#pendingChunks.push(chunk);
                 const size = this.#pendingChunks.reduce((acc, chunk) => acc + chunk.byteLength, 0);
-                const now = Date.now();
+                const now = performance.now();
                 // the first chunk is sent immediately (!this.#lastWriteChunkTime)
                 // the other chunks are sent when watermark is reached (size >= HIGH_WATERMARK) 
                 // or if elapsed 50ms of last send (now - this.#lastWriteChunkTime > 50)
@@ -173,7 +173,7 @@ module.exports = class Response extends Writable {
                                 const size = this.#pendingChunks.reduce((acc, chunk) => acc + chunk.byteLength, 0);
                                 this._res.write(Buffer.concat(this.#pendingChunks, size));
                                 this.#pendingChunks = [];
-                                this.#lastWriteChunkTime = Date.now();
+                                this.#lastWriteChunkTime = performance.now();
                             }
                         });
                     }, 50);

--- a/src/response.js
+++ b/src/response.js
@@ -173,7 +173,7 @@ module.exports = class Response extends Writable {
                                 const size = this.#pendingChunks.reduce((acc, chunk) => acc + chunk.byteLength, 0);
                                 this._res.write(Buffer.concat(this.#pendingChunks, size));
                                 this.#pendingChunks = [];
-                                this.#lastWriteChunkTime = now;
+                                this.#lastWriteChunkTime = Date.now();
                             }
                         });
                     }, 50);


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
> Date.now() may have been impacted by system and user clock adjustments

This fixes a small chance that a system clock change will occur while writing to the stream.

fix https://github.com/dimdenGD/ultimate-express/issues/215