### PR TITLE
fix: add setter for baseUrl (#86)

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -135,6 +135,10 @@ module.exports = class Request extends Readable {
         return match ? match[0] : '';
     }
 
+    set baseUrl(x) {
+        return this._originalPath = x;
+    }
+
     get #host() {
         const trust = this.app.get('trust proxy fn');
         if(!trust) {


### PR DESCRIPTION
The problem in issue #86 was solved by the same person, but was not applied. At the moment the problem is actual and prevents work when using the `moleculer-web` package.