### PR TITLE
re-export some named exports for compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ultimate-express",
-  "version": "1.4.10",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ultimate-express",
-      "version": "1.4.10",
+      "version": "2.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/express": "^4.17.21",

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,9 @@ Application.raw = middlewares.raw;
 module.exports = Application;
 
 // re-export some named exports for compatibility
+exports.application = Application;
+exports.request = Request.prototype;
+exports.response = Response.prototype;
 exports.Router = Router;
 exports.json = middlewares.json;
 exports.raw = middlewares.raw;

--- a/src/index.js
+++ b/src/index.js
@@ -52,3 +52,11 @@ Application.text = middlewares.text;
 Application.raw = middlewares.raw;
 
 module.exports = Application;
+
+// re-export some named exports for compatibility
+exports.Router = Router;
+exports.json = middlewares.json;
+exports.raw = middlewares.raw;
+exports.static = middlewares.static;
+exports.text = middlewares.text;
+exports.urlencoded = middlewares.urlencoded;


### PR DESCRIPTION
some named exports are missing, which breaks [compatibility with express](https://github.com/expressjs/express/blob/master/lib/express.js#L58-L81) when using named imports in ESM eg:

```js
import { Router } from 'ultimate-express';
```

which currently will throw:

```
SyntaxError: Named export 'Router' not found. The requested module 'ultimate-express' is a CommonJS module, which may not support all module.exports as named exports.
```