### PR TITLE
perf: typeof will be faster (vs instanceof)

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -153,7 +153,7 @@ module.exports = class Router extends EventEmitter {
                 all: method === 'ALL' || method === 'USE',
                 gettable: method === 'GET' || method === 'HEAD',
             };
-            if(typeof route.path === 'string' && (route.path.includes(':') || route.path.includes('*') || (route.path.includes('(') && route.path.includes(')'))) && route.pattern instanceof RegExp) {
+            if(typeof route.path === 'string' && (route.path.includes(':') || route.path.includes('*') || (route.path.includes('(') && route.path.includes(')'))) && typeof route.pattern === 'object') {
                 route.complex = true;
             }
             routes.push(route);

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,7 @@ function removeDuplicateSlashes(path) {
 }
 
 function patternToRegex(pattern, isPrefix = false) {
-    if(pattern instanceof RegExp) {
+    if(typeof pattern === 'object') {
         return pattern;
     }
     if(isPrefix && pattern === '') {
@@ -64,19 +64,18 @@ function patternToRegex(pattern, isPrefix = false) {
 }
 
 function needsConversionToRegex(pattern) {
-    if(pattern instanceof RegExp) {
-        return false;
-    }
     if(pattern === '/*') {
         return false;
     }
-
-    return pattern.includes('*') ||
+    if(typeof pattern === 'object') {
+        return false;
+    }
+    return pattern.includes(':') ||
+        pattern.includes('*') ||
         pattern.includes('?') ||
         pattern.includes('+') ||
         pattern.includes('(') ||
         pattern.includes(')') ||
-        pattern.includes(':') ||
         pattern.includes('{') ||
         pattern.includes('}') ||
         pattern.includes('[') ||
@@ -87,7 +86,7 @@ function canBeOptimized(pattern) {
     if(pattern === '/*') {
         return false;
     }
-    if(pattern instanceof RegExp) {
+    if(typeof pattern === 'object') {
         return false;
     }
     if(


### PR DESCRIPTION
typeof will return one of the built in types (Object, undefined and the primitives). The instanceof operator should check the prototype chain and see if the right side has been used as a constructor somewhere along. This is naturally more work.