### PR TITLE
Pass error to next middleware in router

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -350,7 +350,7 @@ module.exports = class Router extends EventEmitter {
             return handler(err, request, response, () => {
                 delete request._error;
                 delete request._errorKey;
-                return request.next();
+                return request.next(err);
             });
         }
         console.error(err);


### PR DESCRIPTION
I'm not sure if this is intentional but I had to do this for my tests to pass when porting from `express`. otherwise I get a 404 instead of a 500 when calling `next(error)` in my error handler. we do this in case error handling itself fails to fallback to `express` default error handling.