### PR TITLE
fix async context breaking in body parser middlewares

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -20,6 +20,7 @@ const bytes = require('bytes');
 const zlib = require('fast-zlib');
 const typeis = require('type-is');
 const querystring = require('fast-querystring');
+const { AsyncResource } = require('async_hooks');
 const { fastQueryParse, NullObject } = require('./utils.js');
 
 function static(root, options) {
@@ -42,6 +43,9 @@ function static(root, options) {
     return (req, res, next) => {
         const iq = req.url.indexOf('?');
         let url;
+
+        next = AsyncResource.bind(next);
+
         try {
             url = decodeURIComponent(iq !== -1 ? req.url.substring(0, iq) : req.url);
         } catch(e) {
@@ -160,6 +164,7 @@ function createBodyParser(defaultType, beforeReturn) {
         let additionalMethods;
 
         return (req, res, next) => {
+            next = AsyncResource.bind(next);
             
             // skip reading body twice
             if(req.bodyRead) {

--- a/tests/tests/middlewares/body-async-context..js
+++ b/tests/tests/middlewares/body-async-context..js
@@ -1,0 +1,39 @@
+// must keep async context
+
+const express = require("express");
+const { AsyncLocalStorage } = require("async_hooks");
+
+const app = express();
+const ctx = new AsyncLocalStorage();
+
+app.use((req, res, next) => {
+    ctx.run('anything', next);
+});
+
+app.use(express.json());
+
+app.post('/abc', (req, res) => {
+    res.setHeader('ctx', ctx.getStore());
+    res.send(req.body);
+});
+
+app.listen(13333, async () => {
+    console.log('Server is running on port 13333');
+
+    const response = await fetch('http://localhost:13333/abc', {
+        method: 'POST',
+        body: JSON.stringify({
+            abc: 123
+        }),
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+    const text = await response.text();
+    console.log(response.headers.get('content-type'));
+    console.log(response.headers.get('ctx'));
+    console.log(text);
+
+    process.exit(0);
+
+});


### PR DESCRIPTION
noticed that the body-parser equivalent middlewares are breaking my async context/store, so i've thought that i'll fix that as the fix is quite easy.

some explanation with code, consider this example:

```js
const { AsyncLocalStorage } = require('node:async_hooks');
const express = require('ultimate-express');

const context = new AsyncLocalStorage();

const app = express();

app.use((req, res, next) => {
    // initialize context
    context.run('anything', next);
});

app.use(express.json());

app.get('/', (req, res) => {
    // returns `anything`
    console.log(context.getStore());

    res.end();
});

app.post('/', (req, res) => {
    // the context is destroyed by json middleware 
    console.log(context.getStore());

    res.end();
});

app.listen(3000);

```

the `context.run` creates context and runs the function within the context, that allows us to access the context store withot passing reference. but the context is only accessible inside the call-stack . hence the GET requests works as intended, but the POST request breaks the context. with the static `AsyncResource.bind` ([docs](https://nodejs.org/api/async_context.html#static-method-asyncresourcebindfn-type-thisarg)) we can simply bind the the current context to the `next` function, that will carry the context to the callback.

not sure if my explanations are sound, so in case the `raw-body` package (used by `body-parser` package) had the exact same issue for long time, but eventually they introduced the `AsyncResource.bind` as well (though in awkward way, as the static method is available since node-16) https://github.com/stream-utils/raw-body/blob/5387b35d77a234a6dcdd089f8042a58a39816d90/index.js#L321-L336