### PR TITLE
fix subapp middleware routes

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -514,7 +514,7 @@ module.exports = class Router extends EventEmitter {
                             if(!strictRouting && req.endsWithSlash && req._originalPath !== '/' && req._opPath[req._opPath.length - 1] === '/') {
                                 req._opPath = req._opPath.slice(0, -1);
                             }
-                            if(req.app.parent && route.callback.constructor.name === 'Application') {
+                            if(req.app.parent && route.callbacks[0]?.constructor.name === 'Application') {
                                 req.app = req.app.parent;
                             }
                         }

--- a/tests/tests/app/app-on-mount.js
+++ b/tests/tests/app/app-on-mount.js
@@ -14,11 +14,31 @@ student.on('mount', (parent) => {
 	console.log('dewd');
 });
 
+teacher.use((req, res, next) => {
+    console.log('teacher 1');
+    next();
+});
+
+teacher.get('/', (req, res) => {
+    res.end('teacher 2');
+})
+
+teacher.use('/student', student);
+
+student.use((req, res, next) => {
+    console.log('student 1');
+    next();
+});
+
 app.use('/student', student);
 app.use('/teacher', teacher);
 
-app.listen(13333, (err) => {
+app.listen(13333, async (err) => {
     console.log("Server is running on port 13333");
-    
+
+    const output = await fetch('http://localhost:13333/teacher').then(res => res.text());
+    console.log(output);
+    await fetch('http://localhost:13333/teacher/student')
+
     process.exit(0);
 });


### PR DESCRIPTION
```
      if(req.app.parent && route.callback.constructor.name === 'Application') {
                                          ^
  
  TypeError: Cannot read properties of undefined (reading 'constructor')
```