### PR TITLE
feat: add Node.js version 25 to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 23]
+        node-version: [20, 22, 24, 25]
     steps:
       - name: Checkout Source Tree
         uses: actions/checkout@v3


### PR DESCRIPTION
https://nodejs.org/en/blog/release/v25.0.0