### PR TITLE
chore(deps): update dependencies to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
       },
       "devDependencies": {
         "@codechecks/client": "^0.1.12",
-        "better-sse": "^0.15.1",
+        "better-sse": "^0.14.1",
         "body-parser": "^2.2.1",
         "compression": "^1.8.1",
         "cookie-parser": "^1.4.7",
@@ -1457,9 +1457,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/better-sse": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/better-sse/-/better-sse-0.15.1.tgz",
-      "integrity": "sha512-E8YmmIs7P2T5nHM8VG5Pmtp8CgDsIhT+6CYhg+8Gmke5kJb11ohN1jtEXn/2taSr7WkcU3yNTgoqNYvZ/GQ4sw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/better-sse/-/better-sse-0.14.1.tgz",
+      "integrity": "sha512-htQOrymWPKD/LDkRRlgmqS5+xX3p9/BetUQTRshqtwuSk+aQ63RluzHx0CJpY1AYUadCvUex8J+B6XwkGLkZxw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@codechecks/client": "^0.1.12",
-    "better-sse": "^0.15.1",
+    "better-sse": "^0.14.1",
     "body-parser": "^2.2.1",
     "compression": "^1.8.1",
     "cookie-parser": "^1.4.7",


### PR DESCRIPTION
updated:
- cookie from 1.0.2 to 1.1.1
- uWebSockets.js from v20.55.0 to v20.56.0
- body-parser from 2.2.0 to 2.2.1
- errorhandler from 1.5.1 to 1.5.2
- eventsource from 4.0.0 to 4.1.0
- exit-hook from 2.2.1 to 5.0.1
- express-handlebars from 8.0.3 to 8.0.4
- express-rate-limit from 8.1.0 to 8.2.1
- multer from 1.4.5-lts.2 to 2.0.2
- pkg-pr-new from 0.0.60 to 0.0.62
- serve-static from 2.2.0 to 2.2.1

Not up updated (breaking test)
- mime-types
- better-sse (wait for https://github.com/MatthewWid/better-sse/issues/113)