### PR TITLE
feat: uws silent

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -59,6 +59,9 @@ class Application extends Router {
         if(typeof settings.threads !== 'number') {
             settings.threads = cpuCount > 1 ? 1 : 0;
         }
+        if(settings.uwsOptions.silent) {
+            uWS._cfg('silent');
+        }
         if(settings.uwsApp) {
             this.uwsApp = settings.uwsApp;
         } else if(settings.http3) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,6 +7,7 @@ declare module "ultimate-express" {
     threads?: number;
     http3?: boolean;
     uwsApp?: uWS.TemplatedApp;
+    silent?: boolean;
   };
 
   namespace express {

--- a/tests/tests/app/app-silent.js
+++ b/tests/tests/app/app-silent.js
@@ -1,0 +1,21 @@
+// must support uws silent
+const express = require("express");
+
+const app = express({
+  uwsOptions: {
+    silent: true,
+  },
+});
+
+app.get("/asdf", (req, res) => {
+  res.send("asdf");
+});
+
+app.listen(13333, async () => {
+  console.log("Server is running on port 13333");
+
+  const outputs = await fetch("http://localhost:13333/asdf").then((res) => res.text());
+
+  console.log(outputs);
+  process.exit(0);
+});


### PR DESCRIPTION
I noticed that in the uwebsockets.js set `uWebSockets._cfg('silent');` into benchmarks, eg.:
https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/JavaScript/uwebsockets.js/src/server.js#L19

it is not documented, but it exists in the source code
https://github.com/uNetworking/uWebSockets.js/blob/ff48755d2f5428973d87f166f40ede34995bee5a/src/addon.cpp#L159

https://github.com/search?q=repo%3AuNetworking%2FuWebSockets%20noMark&type=code

it's probably something that silences log/warning.

With this PR I want expose a settings for use the same option into ultimate-express benchmark