### PR TITLE
fix(test): res.sendFile() on nodejs 24 sometimes fails for timeout

### DIFF
--- a/tests/tests/res/res-send-file-large.js
+++ b/tests/tests/res/res-send-file-large.js
@@ -3,20 +3,25 @@
 const express = require("express");
 const app = express();
 
-app.get('/test', (req, res) => {
-    res.sendFile('tests/parts/large-file.json', { root: "." });
+app.get("/test", (req, res) => {
+  res.sendFile("tests/parts/large-file.json", { root: "." });
 });
 
 app.listen(13333, async () => {
-    console.log('Server is running on port 13333');
+  console.log("Server is running on port 13333");
 
-    const response = await fetch('http://localhost:13333/test');
-    const text = await response.text();
-    let out = '';
-    for (let i = 0; i < text.length; i += 1000) {
-        out += text.slice(i, i + 1);
-    }
-    console.log(out);
-    console.log(response.headers.get('Content-Type').toLowerCase(), response.headers.get('Content-Length'));
+  const response = await fetch("http://localhost:13333/test");
+  const text = await response.text();
+  let out = "";
+  for (let i = 0; i < text.length; i += 1000) {
+    out += text.slice(i, i + 1);
+  }
+  console.log(
+    response.headers.get("Content-Type").toLowerCase(),
+    response.headers.get("Content-Length")
+  );
+  process.stdout.write(out, (err) => {
+    if (err) console.log(err);
     process.exit(0);
+  });
 });


### PR DESCRIPTION
test

```
// must support res.sendFile() with large file
```

on nodejs 24 sometimes fails for timeout (https://github.com/dimdenGD/ultimate-express/pull/280 and https://github.com/dimdenGD/ultimate-express/pull/268) due to large `console.log`, `process.stdout.write` seem more stable