### PR TITLE
perf: lazy Proxy of kOutHeaders

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -98,14 +98,25 @@ module.exports = class Response extends Writable {
         }
 
         // support for node internal
-        this[kOutHeaders] = new Proxy(this.headers, {
-            set: (obj, prop, value) => {
-                this.set(prop, value[1]);
-                return true;
+        Object.defineProperty(this, kOutHeaders, {
+            get: () => {
+                const proxy = new Proxy(this.headers, {
+                    set: (obj, prop, value) => {
+                        this.set(prop, value[1]);
+                        return true;
+                    },
+                    get: (obj, prop) => {
+                        return obj[prop];
+                    }
+                });
+                Object.defineProperty(this, kOutHeaders, {
+                    value: proxy,
+                    writable: true,
+                    configurable: true
+                });
+                return proxy;
             },
-            get: (obj, prop) => {
-                return obj[prop];
-            }
+            configurable: true
         });
         this.body = undefined;
         this.on('error', (err) => {


### PR DESCRIPTION
Create a new Proxy only when read kOutHeaders

<!-- benchmark-comment -->
## Benchmark Comparison

| Test | Express req/sec | uExpress req/sec | Express throughput | uExpress throughput | uExpress speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| engines/art | 4.02k | 7.19k | 1.76 MB/sec | 3.16 MB/sec | **1.80x** |
| middlewares/body-urlencoded | 5.59k | 17.39k | 890.88 KB/sec | 2.72 MB/sec | **3.13x** |
| middlewares/compression-file | 3.48k | 6.13k | 1.59 MB/sec | 2.80 MB/sec | **1.76x** |
| middlewares/express-static | 1.87k | 6.12k | 457.09 MB/sec | 1.46 GB/sec | **3.27x** |
| routing/hello-world | 7.71k | 32.84k | 1.28 MB/sec | 5.48 MB/sec | **4.28x** |
| routing/middlewares-100 | 7.20k | 7.78k | 1.13 MB/sec | 1.22 MB/sec | **1.08x** |
| routing/nested-routers | 7.46k | 23.13k | 1.20 MB/sec | 3.73 MB/sec | **3.11x** |
| routing/routes-1000 | 3.32k | 25.05k | 531.63 KB/sec | 3.94 MB/sec | **7.59x** |
| streaming/readable-hash-4mb | 7.87k | 34.10k | 2.91 MB/sec | 12.65 MB/sec | **4.35x** |
| streaming/writable-no-content-length | 471.25 | 447.76 | 2.30 GB/sec | 2.19 GB/sec | **0.95x** |
| streaming/writable-with-content-length | 502.77 | 622.46 | 2.46 GB/sec | 3.04 GB/sec | **1.24x** |

