### PR TITLE
fix: test app.close only test ultimate-express

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -342,10 +342,9 @@ class Application extends Router {
 
     close(callback) {
         if(this.listenCalled) {
-            this.uwsApp.close(callback);
-        } else {
-            if(callback) callback();
-        }
+            this.uwsApp.close();
+        } 
+        if(callback) callback();
     }
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -34,6 +34,9 @@ for (const testCategory of testCategories) {
             }
             let testPath = path.join(__dirname, 'tests', testCategory, testName);
             let testCode = fs.readFileSync(testPath, 'utf8').replace(`const express = require("../../../src/index.js");`, 'const express = require("express");');
+            if(!testCode.includes(`const express = require("express")`)) {
+                throw new Error("Test code does not contain require express");
+            }
             fs.writeFileSync(testPath, testCode);
             let testDescription = testCode.split('\n')[0].slice(2).trim();
 
@@ -56,8 +59,11 @@ for (const testCategory of testCategories) {
                         timeout = setTimeout(() => timeoutFunc('express'), 60000);
                         let expressOutput = (await exec(`node ${testPath}`, {maxBuffer: 1024 * 1024 * 100})).stdout;
                         clearTimeout(timeout);
-
-                        fs.writeFileSync(testPath, testCode.replace(`const express = require("express");`, `const express = require("../../../src/index.js");`));
+                        const newCode = testCode.replace(`const express = require("express");`, `const express = require("../../../src/index.js");`);
+                        if(newCode === testCode) {
+                            throw new Error("Test code does not contain require express");
+                        }
+                        fs.writeFileSync(testPath, newCode);
                         timeout = setTimeout(() => timeoutFunc('ultimate-express'), 60000)
                         let uExpressOutput = (await exec(`node ${testPath}`, {maxBuffer: 1024 * 1024 * 100})).stdout;
                         clearTimeout(timeout);

--- a/tests/tests/app/close.js
+++ b/tests/tests/app/close.js
@@ -4,11 +4,20 @@ const express = require("express");
 
 const app = express();
 
-const server = app.listen(13333, () => {
+const server = app.listen(13333, (err) => {
+    if (err) {
+        console.error(err);
+        process.exit(1);
+    }
     console.log("Server is listening on port 13333");
 });
 
-server.close(() => {
-    console.log("Server closed successfully");
-    process.exit(0);
-})
+setTimeout(() => {
+    server.close((err) => {
+        console.log("Server closed successfully");
+        if(err){
+            console.log(err);
+        }
+        process.exit(err ? 1 : 0)
+    })
+}, 1000);

--- a/tests/tests/app/close.js
+++ b/tests/tests/app/close.js
@@ -1,6 +1,6 @@
 // must support server.close()
 
-const express = require("../../../src");
+const express = require("express");
 
 const app = express();
 


### PR DESCRIPTION
This test always test only ultimate-express. 

I have also fixed close implementation (see https://unetworking.github.io/uWebSockets.js/generated/interfaces/TemplatedApp.html#close-1), uws don't support callback.

I have also add a control for avoid future test `require("express")` mistake