### PR TITLE
perf: handling backpressure without timer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "statuses": "^2.0.2",
         "tseep": "^1.3.1",
         "type-is": "^2.0.1",
-        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.63.0",
+        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.64.0",
         "vary": "^1.1.2"
       },
       "devDependencies": {
@@ -8443,8 +8443,8 @@
       }
     },
     "node_modules/uWebSockets.js": {
-      "version": "20.63.0",
-      "resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#d584e6247998f725e86db77130de139eda936473",
+      "version": "20.64.0",
+      "resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#09c62a4f6dd5fa2e8103f7409949e9eff53ba4ca",
       "license": "Apache-2.0"
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "statuses": "^2.0.2",
     "tseep": "^1.3.1",
     "type-is": "^2.0.1",
-    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.63.0",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.64.0",
     "vary": "^1.1.2"
   },
   "devDependencies": {

--- a/src/response.js
+++ b/src/response.js
@@ -71,9 +71,7 @@ class Socket extends EventEmitter {
 module.exports = class Response extends Writable {
     #socket = null;
     #ended = false;
-    #pendingChunks = [];
-    #lastWriteChunkTime = 0;
-    #writeTimeout = null;
+    #pendingCallback = null;
     req;
     constructor(res, req, app) {
         super();
@@ -157,36 +155,21 @@ module.exports = class Response extends Writable {
             }
     
             if (this.chunkedTransfer) {
-                this.#pendingChunks.push(chunk);
-                const size = this.#pendingChunks.reduce((acc, chunk) => acc + chunk.byteLength, 0);
-                const now = performance.now();
-                // the first chunk is sent immediately (!this.#lastWriteChunkTime)
-                // the other chunks are sent when watermark is reached (size >= HIGH_WATERMARK) 
-                // or if elapsed 50ms of last send (now - this.#lastWriteChunkTime > 50)
-                if (!this.#lastWriteChunkTime || size >= HIGH_WATERMARK || now - this.#lastWriteChunkTime > 50) {
-                    this._res.write(Buffer.concat(this.#pendingChunks, size));
-                    this.#pendingChunks = [];
-                    this.#lastWriteChunkTime = now;
-                    if(this.#writeTimeout) {
-                        clearTimeout(this.#writeTimeout);
-                        this.#writeTimeout = null;
-                    }
-                } else if(!this.#writeTimeout) {
-                    this.#writeTimeout = setTimeout(() => {
-                        this.#writeTimeout = null;
-                        if(!this.finished && !this.aborted) this._res.cork(() => {
-                            if(this.#pendingChunks.length) {
-                                const size = this.#pendingChunks.reduce((acc, chunk) => acc + chunk.byteLength, 0);
-                                this._res.write(Buffer.concat(this.#pendingChunks, size));
-                                this.#pendingChunks = [];
-                                this.#lastWriteChunkTime = performance.now();
-                            }
-                        });
-                    }, 50);
-                    this.#writeTimeout.unref();
+                const ok = this._res.write(chunk);
+                if (ok) {
+                    this.writingChunk = false;
+                    callback(null);
+                } else {
+                    this.#pendingCallback = callback;
+                    this._res.onWritable(() => {
+                        if (this.aborted || this.finished) return true;
+                        const cb = this.#pendingCallback;
+                        this.#pendingCallback = null;
+                        this.writingChunk = false;
+                        if (cb) cb(null);
+                        return true;
+                    });
                 }
-                this.writingChunk = false;
-                callback(null);
             } else {
                 const lastOffset = this._res.getWriteOffset();
                 const [ok, done] = this._res.tryEnd(chunk, this.totalSize);
@@ -312,11 +295,6 @@ module.exports = class Response extends Writable {
             if(!data && contentLength) {
                 this._res.endWithoutBody(contentLength.toString());
             } else {
-                if(this.#pendingChunks.length) {
-                    this._res.write(Buffer.concat(this.#pendingChunks));
-                    this.#pendingChunks = [];
-                    this.lastWriteChunkTime = 0;
-                }
                 if(data instanceof Buffer) {
                     data = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
                 }


### PR DESCRIPTION
From https://github.com/uNetworking/uWebSockets.js/releases/tag/v20.64.0
> Bumps uWS to v20.77.0 with important backpressure fix (see main repo for explanation)

Tested with
```js
const express = require('../src/index.js');
const compression = require('compression');
const app = express();

// force encoding by query param ?compress=
app.use((req, res, next) => {
  const enc = req.query.compress;
  if (enc) {
    req.headers['accept-encoding'] = enc;
  }
  next();
});

app.use(compression({ threshold: 1 }));
app.use(express.static('tests/parts'));

const PORT = 13335;
app.listen(PORT, () => {
  const base = `http://localhost:${PORT}`;
  const files = ['small-file.json', 'medium-file.json', 'large-file.json'];
  const encodings = ['gzip', 'br', 'deflate'];

  console.log(`\n  Server on ${base}\n`);
  console.log('  === Links ===\n');

  for (const file of files) {
    console.log(`  ${file}`);
    console.log(`     ${'identity'.padEnd(8)} : ${base}/${file}?compress=identity`);
    for (const enc of encodings) {
      console.log(`     ${enc.padEnd(8)} : ${base}/${file}?compress=${enc}`);
    }
    console.log();
  }
});
```
Works on Chrome/Windows with gzip, br and deflate

Ref https://github.com/uNetworking/uWebSockets.js/issues/1249
