### PR TITLE
chore: enable garbage collection in benchmark script

### DIFF
--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -263,6 +263,9 @@ function formatBytesPerSec(bytes) {
 }
 
 async function runScenario(framework, scenarioName, scenario, durationSeconds) {
+    if (global.gc) {
+        global.gc();
+    }
     const { server, stderrRef } = startScenarioServer(framework, scenarioName);
 
     try {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "node tests/index.js",
     "test:types": "tsd --files tests/types/*.test-d.ts",
-    "benchmark:compare": "node benchmark/run.js",
+    "benchmark:compare": "node --expose-gc benchmark/run.js",
     "cover": "npm run cover:unit && npm run cover:report",
     "cover:unit": "nyc --silent npm run test",
     "cover:report": "nyc report --reporter=html"


### PR DESCRIPTION
This change improves benchmark consistency by reducing memory noise between scenario runs. Invoke `global.gc()` (force run garbage collector) before starting each benchmark scenario, if the GC API is available.