### PR TITLE
perf: optimize body parsing and buffering in request handling with onDataV2

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -232,6 +232,36 @@ function createBodyParser(defaultType, beforeReturn) {
 
             req.bodyRead = true;
 
+            function appendChunk(state, chunk, maxSize, preferredCapacity = 0) {
+                const requiredSize = state.writeOffset + chunk.length;
+                if(requiredSize > maxSize) {
+                    return false;
+                }
+                if(state.buffer === null) {
+                    const capacity = Math.max(chunk.length, preferredCapacity || 0);
+                    state.buffer = Buffer.allocUnsafe(capacity);
+                } else if(requiredSize > state.buffer.length) {
+                    const capacity = Math.max(requiredSize, state.buffer.length * 2, preferredCapacity || 0);
+                    const nextBuffer = Buffer.allocUnsafe(capacity);
+                    state.buffer.copy(nextBuffer, 0, 0, state.writeOffset);
+                    state.buffer = nextBuffer;
+                }
+                chunk.copy(state.buffer, state.writeOffset);
+                state.writeOffset = requiredSize;
+                return true;
+            }
+
+            function getSafePreallocatedSize(chunkLength, maxRemainingBodyLength, maxSize) {
+                if(maxRemainingBodyLength <= 0n) {
+                    return chunkLength;
+                }
+                const maxAllowedRemaining = BigInt(maxSize - chunkLength);
+                if(maxRemainingBodyLength > maxAllowedRemaining) {
+                    return 0;
+                }
+                return chunkLength + Number(maxRemainingBodyLength);
+            }
+
             function onComplete(buf) {
                 if(options.verify) {
                     try {
@@ -248,28 +278,20 @@ function createBodyParser(defaultType, beforeReturn) {
             // otherwise we need to use a stream since it already started streaming it
             if(!req.receivedData) {
                 if(!inflate) {
-                    let bodyBuffer = null;
-                    let writeOffset = 0;
+                    const bodyState = {
+                        buffer: null,
+                        writeOffset: 0
+                    };
                     req._res.onDataV2((ab, maxRemainingBodyLength) => {
                         const chunk = Buffer.from(ab);
-                        if(bodyBuffer === null) {
-                            const totalSize = chunk.length + Number(maxRemainingBodyLength);
-                            if(totalSize > options.limit) {
-                                return next(new Error('Request entity too large'));
-                            }
-                            if(maxRemainingBodyLength === 0n) {
-                                bodyBuffer = Buffer.from(chunk);
-                            } else {
-                                bodyBuffer = Buffer.allocUnsafe(totalSize);
-                                chunk.copy(bodyBuffer, 0);
-                            }
-                            writeOffset = chunk.length;
-                        } else {
-                            chunk.copy(bodyBuffer, writeOffset);
-                            writeOffset += chunk.length;
+                        const preferredCapacity = bodyState.buffer === null
+                            ? getSafePreallocatedSize(chunk.length, maxRemainingBodyLength, options.limit)
+                            : 0;
+                        if(!appendChunk(bodyState, chunk, options.limit, preferredCapacity)) {
+                            return next(new Error('Request entity too large'));
                         }
                         if(maxRemainingBodyLength === 0n) {
-                            onComplete(bodyBuffer);
+                            onComplete(bodyState.buffer.subarray(0, bodyState.writeOffset));
                         }
                     });
                 } else {

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -222,9 +222,7 @@ function createBodyParser(defaultType, beforeReturn) {
                 return next();
             }
 
-            const abs = [];
             let inflate;
-            let totalSize = 0;
             if(options.inflate) {
                 inflate = createInflate(req.headers['content-encoding']);
                 if(inflate === false) {
@@ -234,25 +232,7 @@ function createBodyParser(defaultType, beforeReturn) {
 
             req.bodyRead = true;
 
-            function onData(buf) {
-                if(!Buffer.isBuffer(buf)) {
-                    buf = Buffer.from(buf);
-                }
-                if(inflate) {
-                    buf = inflate.process(buf);
-                }
-
-                // shallow copy, to avoid shared references for large bodies.
-                abs.push(Buffer.from(buf));
-
-                totalSize += buf.length;
-                if(totalSize > options.limit) {
-                    return next(new Error('Request entity too large'));
-                }
-            }
-    
-            function onEnd() {
-                const buf = Buffer.concat(abs);
+            function onComplete(buf) {
                 if(options.verify) {
                     try {
                         options.verify(req, res, buf);
@@ -267,15 +247,66 @@ function createBodyParser(defaultType, beforeReturn) {
             // if we are fast enough (not async), we can do it
             // otherwise we need to use a stream since it already started streaming it
             if(!req.receivedData) {
-                req._res.onData((ab, isLast) => {
-                    onData(ab);
-                    if(isLast) {
-                        onEnd();
+                if(!inflate) {
+                    let bodyBuffer = null;
+                    let writeOffset = 0;
+                    req._res.onDataV2((ab, maxRemainingBodyLength) => {
+                        const chunk = Buffer.from(ab);
+                        if(bodyBuffer === null) {
+                            const totalSize = chunk.length + Number(maxRemainingBodyLength);
+                            if(totalSize > options.limit) {
+                                return next(new Error('Request entity too large'));
+                            }
+                            if(maxRemainingBodyLength === 0n) {
+                                bodyBuffer = Buffer.from(chunk);
+                            } else {
+                                bodyBuffer = Buffer.allocUnsafe(totalSize);
+                                chunk.copy(bodyBuffer, 0);
+                            }
+                            writeOffset = chunk.length;
+                        } else {
+                            chunk.copy(bodyBuffer, writeOffset);
+                            writeOffset += chunk.length;
+                        }
+                        if(maxRemainingBodyLength === 0n) {
+                            onComplete(bodyBuffer);
+                        }
+                    });
+                } else {
+                    const abs = [];
+                    let totalSize = 0;
+                    req._res.onDataV2((ab, maxRemainingBodyLength) => {
+                        let buf = Buffer.from(ab);
+                        buf = inflate.process(buf);
+                        abs.push(Buffer.from(buf));
+                        totalSize += buf.length;
+                        if(totalSize > options.limit) {
+                            return next(new Error('Request entity too large'));
+                        }
+                        if(maxRemainingBodyLength === 0n) {
+                            onComplete(Buffer.concat(abs, totalSize));
+                        }
+                    });
+                }
+            } else {
+                const abs = [];
+                let totalSize = 0;
+                req.on('data', (buf) => {
+                    if(!Buffer.isBuffer(buf)) {
+                        buf = Buffer.from(buf);
+                    }
+                    if(inflate) {
+                        buf = inflate.process(buf);
+                    }
+                    abs.push(Buffer.from(buf));
+                    totalSize += buf.length;
+                    if(totalSize > options.limit) {
+                        return next(new Error('Request entity too large'));
                     }
                 });
-            } else {
-                req.on('data', onData);
-                req.on('end', onEnd);
+                req.on('end', () => {
+                    onComplete(Buffer.concat(abs, totalSize));
+                });
             }
         }
     }

--- a/src/request.js
+++ b/src/request.js
@@ -41,6 +41,8 @@ module.exports = class Request extends Readable {
     #needsData = false;
     #doneReadingData = false;
     #bufferedData = null;
+    #readOffset = 0;
+    #writeOffset = 0;
     body;
     res;
     optimizedParams;
@@ -100,17 +102,26 @@ module.exports = class Request extends Readable {
             this.method === 'PATCH' || 
             (additionalMethods && additionalMethods.includes(this.method))
         ) {
-            this.#bufferedData = Buffer.allocUnsafe(0);
-            this._res.onData((ab, isLast) => {
+            this._res.onDataV2((ab, maxRemainingBodyLength) => {
                 // make stream actually readable
                 this.receivedData = true;
-                if(isLast) {
+                if(maxRemainingBodyLength === 0n) {
                     this.#doneReadingData = true;
                 }
-                // instead of pushing data immediately, buffer it
-                // because writable streams cant handle the amount of data uWS gives (usually 512kb+)
                 const chunk = Buffer.from(ab);
-                this.#bufferedData = Buffer.concat([this.#bufferedData, chunk]);
+                if(this.#bufferedData === null) {
+                    if(maxRemainingBodyLength === 0n) {
+                        this.#bufferedData = Buffer.from(chunk);
+                    } else {
+                        const totalSize = chunk.length + Number(maxRemainingBodyLength);
+                        this.#bufferedData = Buffer.allocUnsafe(totalSize);
+                        chunk.copy(this.#bufferedData, 0);
+                    }
+                    this.#writeOffset = chunk.length;
+                } else {
+                    chunk.copy(this.#bufferedData, this.#writeOffset);
+                    this.#writeOffset += chunk.length;
+                }
                 
                 if(this.#needsData) {
                     this.#needsData = false;
@@ -127,14 +138,16 @@ module.exports = class Request extends Readable {
     }
 
     _read() {
-        if(!this.receivedData || !this.#bufferedData) {
+        if(!this.receivedData || this.#bufferedData === null) {
             this.#needsData = true;
             return;
         }
-        if(this.#bufferedData.length > 0) {
+        const available = this.#writeOffset - this.#readOffset;
+        if(available > 0) {
             // push 128kb chunks
-            const chunk = this.#bufferedData.subarray(0, 1024 * 128);
-            this.#bufferedData = this.#bufferedData.subarray(1024 * 128);
+            const size = Math.min(available, 1024 * 128);
+            const chunk = this.#bufferedData.subarray(this.#readOffset, this.#readOffset + size);
+            this.#readOffset += size;
             this.push(chunk);
         } else if(this.#doneReadingData) {
             this.push(null);

--- a/src/request.js
+++ b/src/request.js
@@ -109,19 +109,8 @@ module.exports = class Request extends Readable {
                     this.#doneReadingData = true;
                 }
                 const chunk = Buffer.from(ab);
-                if(this.#bufferedData === null) {
-                    if(maxRemainingBodyLength === 0n) {
-                        this.#bufferedData = Buffer.from(chunk);
-                    } else {
-                        const totalSize = chunk.length + Number(maxRemainingBodyLength);
-                        this.#bufferedData = Buffer.allocUnsafe(totalSize);
-                        chunk.copy(this.#bufferedData, 0);
-                    }
-                    this.#writeOffset = chunk.length;
-                } else {
-                    chunk.copy(this.#bufferedData, this.#writeOffset);
-                    this.#writeOffset += chunk.length;
-                }
+                const preferredCapacity = maxRemainingBodyLength === 0n ? chunk.length : 0;
+                this.#appendBufferedChunk(chunk, preferredCapacity);
                 
                 if(this.#needsData) {
                     this.#needsData = false;
@@ -504,5 +493,35 @@ module.exports = class Request extends Readable {
             res.push(val[0], val[1]);
         }
         return res;
+    }
+
+    #appendBufferedChunk(chunk, preferredCapacity = 0) {
+        const additionalSize = chunk.length;
+        const requiredSize = this.#writeOffset + additionalSize;
+        if(this.#bufferedData === null) {
+            this.#bufferedData = Buffer.allocUnsafe(Math.max(additionalSize, preferredCapacity || 0));
+            return;
+        }
+        if(requiredSize <= this.#bufferedData.length) {
+            return;
+        }
+
+        const unreadSize = this.#writeOffset - this.#readOffset;
+        if(this.#readOffset > 0) {
+            this.#bufferedData.copy(this.#bufferedData, 0, this.#readOffset, this.#writeOffset);
+            this.#readOffset = 0;
+            this.#writeOffset = unreadSize;
+        }
+
+        const nextRequiredSize = this.#writeOffset + additionalSize;
+        if(nextRequiredSize <= this.#bufferedData.length) {
+            return;
+        }
+
+        const nextBuffer = Buffer.allocUnsafe(Math.max(nextRequiredSize, this.#bufferedData.length * 2, preferredCapacity || 0));
+        this.#bufferedData.copy(nextBuffer, 0, 0, this.#writeOffset);
+        this.#bufferedData = nextBuffer;
+        chunk.copy(this.#bufferedData, this.#writeOffset);
+        this.#writeOffset += chunk.length;
     }
 }

--- a/src/request.js
+++ b/src/request.js
@@ -500,27 +500,22 @@ module.exports = class Request extends Readable {
         const requiredSize = this.#writeOffset + additionalSize;
         if(this.#bufferedData === null) {
             this.#bufferedData = Buffer.allocUnsafe(Math.max(additionalSize, preferredCapacity || 0));
-            return;
-        }
-        if(requiredSize <= this.#bufferedData.length) {
-            return;
+        } else if(requiredSize > this.#bufferedData.length) {
+            const unreadSize = this.#writeOffset - this.#readOffset;
+            if(this.#readOffset > 0) {
+                this.#bufferedData.copy(this.#bufferedData, 0, this.#readOffset, this.#writeOffset);
+                this.#readOffset = 0;
+                this.#writeOffset = unreadSize;
+            }
+
+            const nextRequiredSize = this.#writeOffset + additionalSize;
+            if(nextRequiredSize > this.#bufferedData.length) {
+                const nextBuffer = Buffer.allocUnsafe(Math.max(nextRequiredSize, this.#bufferedData.length * 2, preferredCapacity || 0));
+                this.#bufferedData.copy(nextBuffer, 0, 0, this.#writeOffset);
+                this.#bufferedData = nextBuffer;
+            }
         }
 
-        const unreadSize = this.#writeOffset - this.#readOffset;
-        if(this.#readOffset > 0) {
-            this.#bufferedData.copy(this.#bufferedData, 0, this.#readOffset, this.#writeOffset);
-            this.#readOffset = 0;
-            this.#writeOffset = unreadSize;
-        }
-
-        const nextRequiredSize = this.#writeOffset + additionalSize;
-        if(nextRequiredSize <= this.#bufferedData.length) {
-            return;
-        }
-
-        const nextBuffer = Buffer.allocUnsafe(Math.max(nextRequiredSize, this.#bufferedData.length * 2, preferredCapacity || 0));
-        this.#bufferedData.copy(nextBuffer, 0, 0, this.#writeOffset);
-        this.#bufferedData = nextBuffer;
         chunk.copy(this.#bufferedData, this.#writeOffset);
         this.#writeOffset += chunk.length;
     }


### PR DESCRIPTION
Switches from `onData` to `onDataV2` which exposes `maxRemainingBodyLength` the exact number of bytes remaining in the request body. This enables several performance optimizations like pre-allocated body buffer.

##  [PR BENCHMARK](https://github.com/dimdenGD/ultimate-express/actions/runs/24610822169/artifacts/6512727297)

| Test | Express req/sec | uExpress req/sec | Express throughput | uExpress throughput | uExpress speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| engines/art | 4.32k | 10.19k | 1.89 MB/sec | 4.48 MB/sec | **2.37x** |
| middlewares/body-urlencoded | 7.15k | 33.86k | 1.11 MB/sec | 5.30 MB/sec | **4.77x** |
| middlewares/compression-file | 4.76k | 6.97k | 2.17 MB/sec | 3.18 MB/sec | **1.47x** |
| middlewares/express-static | 2.42k | 6.89k | 592.86 MB/sec | 1.64 GB/sec | **2.83x** |
| routing/hello-world | 11.07k | 70.89k | 1.84 MB/sec | 11.83 MB/sec | **6.43x** |
| routing/middlewares-100 | 10.14k | 14.65k | 1.59 MB/sec | 2.31 MB/sec | **1.45x** |
| routing/nested-routers | 10.18k | 59.03k | 1.63 MB/sec | 9.51 MB/sec | **5.83x** |
| routing/routes-1000 | 3.27k | 54.06k | 523.02 KB/sec | 8.51 MB/sec | **16.66x** |
| streaming/readable-hash-4mb | 10.82k | 69.21k | 4.00 MB/sec | 25.67 MB/sec | **6.42x** |
| streaming/writable-no-content-length | 500.09 | 533.87 | 2.44 GB/sec | 2.62 GB/sec | **1.07x** |
| streaming/writable-with-content-length | 513.71 | 417.06 | 2.51 GB/sec | 2.05 GB/sec | **0.82x** |



## [MASTER BENCHMARK](https://github.com/dimdenGD/ultimate-express/commit/1e0dd2d9571b24c2b7f25edcc896d0f54228410e#commitcomment-182676923)

| Test | Express req/sec | uExpress req/sec | Express throughput | uExpress throughput | uExpress speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| engines/art | 4.06k | 7.86k | 1.78 MB/sec | 3.46 MB/sec | **1.94x** |
| middlewares/body-urlencoded | 5.84k | 18.26k | 931.84 KB/sec | 2.86 MB/sec | **3.14x** |
| middlewares/compression-file | 3.26k | 6.72k | 1.49 MB/sec | 3.07 MB/sec | **2.06x** |
| middlewares/express-static | 2.01k | 7.19k | 492.15 MB/sec | 1.72 GB/sec | **3.58x** |
| routing/hello-world | 7.74k | 52.99k | 1.28 MB/sec | 8.84 MB/sec | **6.91x** |
| routing/middlewares-100 | 7.54k | 12.55k | 1.18 MB/sec | 1.97 MB/sec | **1.67x** |
| routing/nested-routers | 7.29k | 42.18k | 1.17 MB/sec | 6.80 MB/sec | **5.81x** |
| routing/routes-1000 | 3.41k | 38.51k | 545.72 KB/sec | 6.06 MB/sec | **11.37x** |
| streaming/readable-hash-4mb | 7.87k | 53.41k | 2.91 MB/sec | 19.82 MB/sec | **6.81x** |
| streaming/writable-no-content-length | 542.93 | 581.82 | 2.66 GB/sec | 2.85 GB/sec | **1.07x** |
| streaming/writable-with-content-length | 560.60 | 627.22 | 2.74 GB/sec | 3.07 GB/sec | **1.12x** |

