### PR TITLE
perf: optimize body buffering with pre-allocation strategy with onDataV2

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -267,10 +267,40 @@ function createBodyParser(defaultType, beforeReturn) {
             // if we are fast enough (not async), we can do it
             // otherwise we need to use a stream since it already started streaming it
             if(!req.receivedData) {
-                req._res.onData((ab, isLast) => {
-                    onData(ab);
+                let preAllocBuf = null;
+                let offset = 0;
+                req._res.onDataV2((ab, maxRemainingBodyLength) => {
+                    const isLast = maxRemainingBodyLength === 0n;
+                    
+                    if(preAllocBuf === null && !inflate) {
+                        const totalSize = ab.byteLength + Number(maxRemainingBodyLength);
+                        if(totalSize <= options.limit) {
+                            preAllocBuf = Buffer.allocUnsafe(totalSize);
+                        }
+                    }
+                    
+                    if(preAllocBuf !== null) {
+                        const chunk = Buffer.from(ab);
+                        chunk.copy(preAllocBuf, offset);
+                        offset += chunk.length;
+                    } else {
+                        onData(ab);
+                    }
+                    
                     if(isLast) {
-                        onEnd();
+                        if(preAllocBuf !== null) {
+                            const buf = preAllocBuf;
+                            if(options.verify) {
+                                try {
+                                    options.verify(req, res, buf);
+                                } catch(e) {
+                                    return next(e);
+                                }
+                            }
+                            beforeReturn(req, res, next, options, buf);
+                        } else {
+                            onEnd();
+                        }
                     }
                 });
             } else {

--- a/src/request.js
+++ b/src/request.js
@@ -104,7 +104,7 @@ module.exports = class Request extends Readable {
             let chunks = null;
             let preAllocBuf = null;
             let offset = 0;
-            const MAX_PREALLOC = 10 * 1024 * 1024; // 10MB
+            const MAX_PREALLOC = 10 * 1024 * 1024; // 10 MB
 
             this._res.onDataV2((ab, maxRemainingBodyLength) => {
                 this.receivedData = true;

--- a/src/request.js
+++ b/src/request.js
@@ -100,17 +100,47 @@ module.exports = class Request extends Readable {
             this.method === 'PATCH' || 
             (additionalMethods && additionalMethods.includes(this.method))
         ) {
-            this.#bufferedData = Buffer.allocUnsafe(0);
-            this._res.onData((ab, isLast) => {
-                // make stream actually readable
+            this.#bufferedData = null;
+            let chunks = null;
+            let preAllocBuf = null;
+            let offset = 0;
+            const MAX_PREALLOC = 10 * 1024 * 1024; // 10MB
+
+            this._res.onDataV2((ab, maxRemainingBodyLength) => {
                 this.receivedData = true;
+                const isLast = maxRemainingBodyLength === 0n;
+                
                 if(isLast) {
                     this.#doneReadingData = true;
                 }
-                // instead of pushing data immediately, buffer it
-                // because writable streams cant handle the amount of data uWS gives (usually 512kb+)
+                
                 const chunk = Buffer.from(ab);
-                this.#bufferedData = Buffer.concat([this.#bufferedData, chunk]);
+                
+                if(preAllocBuf === null && chunks === null) {
+                    const totalSize = chunk.length + Number(maxRemainingBodyLength);
+                    if(totalSize <= MAX_PREALLOC) {
+                        preAllocBuf = Buffer.allocUnsafe(totalSize);
+                        chunk.copy(preAllocBuf, 0);
+                        offset = chunk.length;
+                    } else {
+                        chunks = [chunk];
+                    }
+                } else if(preAllocBuf !== null) {
+                    chunk.copy(preAllocBuf, offset);
+                    offset += chunk.length;
+                } else {
+                    chunks.push(chunk);
+                }
+                
+                if(isLast) {
+                    if(preAllocBuf !== null) {
+                        this.#bufferedData = preAllocBuf;
+                    } else if(chunks !== null) {
+                        this.#bufferedData = Buffer.concat(chunks);
+                    } else {
+                        this.#bufferedData = Buffer.allocUnsafe(0);
+                    }
+                }
                 
                 if(this.#needsData) {
                     this.#needsData = false;


### PR DESCRIPTION
following https://github.com/dimdenGD/ultimate-express/pull/335

`onDataV2` exposes `maxRemainingBodyLength` (`BigInt`) the exact number of bytes remaining in the request body. This enables pre-allocating a single buffer of known size on the first chunk, eliminating repeated `Buffer.concat` operations.

middlewares.js
- When `inflate` is off and `totalSize` <= `options.limit`, a single `Buffer.allocUnsafe(totalSize)` is created and chunks are copied via offset
- Falls back to the existing dynamic buffering (`onData`/`onEnd`) otherwise
- Chunked requests (where `maxRemainingBodyLength` is unreliable) automatically take the fallback path

request.js
- When` totalSize` <= 10MB, pre-allocates a single buffer with offset copy
- Otherwise uses an array of chunks with a single final `Buffer.concat` (replacing the old per-chunk `Buffer.concat` which was O(n^2))

<!-- benchmark-comment -->
## Benchmark PR

| Test | Express req/sec | uExpress req/sec | Express throughput | uExpress throughput | uExpress speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| engines/art | 4.25k | 8.16k | 1.86 MB/sec | 3.59 MB/sec | **1.93x** |
| middlewares/body-urlencoded | 6.02k | 19.74k | 962.56 KB/sec | 3.09 MB/sec | **3.29x** |
| middlewares/compression-file | 3.86k | 6.65k | 1.76 MB/sec | 3.04 MB/sec | **1.73x** |
| middlewares/express-static | 2.15k | 7.16k | 526.88 MB/sec | 1.71 GB/sec | **3.32x** |
| routing/hello-world | 7.88k | 51.95k | 1.31 MB/sec | 8.67 MB/sec | **6.62x** |
| routing/middlewares-100 | 8.16k | 13.46k | 1.28 MB/sec | 2.12 MB/sec | **1.66x** |
| routing/nested-routers | 7.54k | 37.05k | 1.21 MB/sec | 5.97 MB/sec | **4.93x** |
| routing/routes-1000 | 3.51k | 33.64k | 562.04 KB/sec | 5.29 MB/sec | **9.64x** |
| streaming/readable-hash-4mb | 8.20k | 57.32k | 3.03 MB/sec | 21.27 MB/sec | **7.02x** |
| streaming/writable-no-content-length | 568.74 | 596.14 | 2.78 GB/sec | 2.91 GB/sec | **1.05x** |
| streaming/writable-with-content-length | 571.09 | 642.63 | 2.79 GB/sec | 3.15 GB/sec | **1.13x** |

<!-- benchmark-comment -->
## [Benchmark MASTER](https://github.com/dimdenGD/ultimate-express/commit/8ff17b6e456cef8402aea4770fb53436209ca7e8)

| Test | Express req/sec | uExpress req/sec | Express throughput | uExpress throughput | uExpress speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| engines/art | 4.27k | 10.25k | 1.87 MB/sec | 4.51 MB/sec | **2.41x** |
| middlewares/body-urlencoded | 7.21k | 33.87k | 1.12 MB/sec | 5.30 MB/sec | **4.73x** |
| middlewares/compression-file | 4.70k | 7.09k | 2.14 MB/sec | 3.24 MB/sec | **1.51x** |
| middlewares/express-static | 2.41k | 6.99k | 588.67 MB/sec | 1.67 GB/sec | **2.90x** |
| routing/hello-world | 11.04k | 73.54k | 1.83 MB/sec | 12.27 MB/sec | **6.70x** |
| routing/middlewares-100 | 10.41k | 14.25k | 1.63 MB/sec | 2.24 MB/sec | **1.37x** |
| routing/nested-routers | 10.43k | 58.00k | 1.67 MB/sec | 9.35 MB/sec | **5.60x** |
| routing/routes-1000 | 3.25k | 54.98k | 520.08 KB/sec | 8.65 MB/sec | **17.03x** |
| streaming/readable-hash-4mb | 11.30k | 70.39k | 4.18 MB/sec | 26.11 MB/sec | **6.25x** |
| streaming/writable-no-content-length | 519.59 | 540.90 | 2.54 GB/sec | 2.65 GB/sec | **1.04x** |
| streaming/writable-with-content-length | 514.43 | 418.96 | 2.51 GB/sec | 2.05 GB/sec | **0.82x** |


