### PR TITLE
uWebSockets.js v20.67.0 (NodeJS 26)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
     steps:
       - name: Checkout Source Tree
         uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "statuses": "^2.0.2",
         "tseep": "^1.3.1",
         "type-is": "^2.0.1",
-        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.66.0",
+        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0",
         "vary": "^1.1.2"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8443,8 +8443,8 @@
       }
     },
     "node_modules/uWebSockets.js": {
-      "version": "20.66.0",
-      "resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#a63031f40f76dc2422e8da736c04217053e9db2b",
+      "version": "20.67.0",
+      "resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#e0f56ebb4b349017f006e14d1cd29052f2a7121d",
       "license": "Apache-2.0"
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "statuses": "^2.0.2",
     "tseep": "^1.3.1",
     "type-is": "^2.0.1",
-    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.66.0",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0",
     "vary": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
From https://github.com/uNetworking/uWebSockets.js/releases/tag/v20.67.0

> This release removes Node.js 25 & Node.js 20 support and adds Node.js 26 support.

I have also removed Node.js 20 from CI, now it's EOL https://nodejs.org/en/download/archive/v20.20.2