### PR TITLE
feat(test): add SKIP_V4 e SKIP_V5 for test

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -10,6 +10,8 @@ const childProcess = require("node:child_process");
 const exec = require("util").promisify(childProcess.exec)
 const assert = require("node:assert");
 
+const TEST_TIMEOUT = 60000;
+
 const testPath = path.join(__dirname, 'tests');
 
 let testCategories = fs.readdirSync(testPath).sort((a, b) => parseInt(a) - parseInt(b));
@@ -40,11 +42,12 @@ for (const testCategory of testCategories) {
             fs.writeFileSync(testPath, testCode);
             let testDescription = testCode.split('\n')[0].slice(2).trim();
 
-            const skip = testDescription.endsWith('OFF')
+            const lastToken = testDescription.split(' ').pop();
+            const marker = ['SKIP_V4', 'SKIP_V5', 'OFF'].includes(lastToken) ? lastToken : null;
 
             await new Promise(resolve => {
                 test(testDescription, async (t) => {
-                    if (skip) {
+                    if (marker === 'OFF') {
                         t.skip();
                         return resolve();
                     }
@@ -55,24 +58,37 @@ for (const testCategory of testCategories) {
                         throw `${module} timed out`;
                     };
 
+                    let execTest = async (testPath) => {
+                        return (await exec(`node ${testPath}`, {maxBuffer: 1024 * 1024 * 100})).stdout
+                    }
+
                     try {
                         // Run with Express 4
-                        timeout = setTimeout(() => timeoutFunc('express'), 60000);
-                        let expressOutput = (await exec(`node ${testPath}`, {maxBuffer: 1024 * 1024 * 100})).stdout;
-                        clearTimeout(timeout);
+                        let express4Output = null;
+                        if (marker !== 'SKIP_V4') {
+                            timeout = setTimeout(() => timeoutFunc('express'), TEST_TIMEOUT);
+                            express4Output = await execTest(testPath);
+                            clearTimeout(timeout);
+                        } else {
+                            t.diagnostic('express4: SKIPPED');
+                        }
 
-                        // Run with Express 5
+                        // Run with Express 5 (skip if SKIP_V5)
                         let express5Output = null;
                         let express5Error = null;
-                        const express5Code = testCode.replace(`const express = require("express");`, `const express = require("express5");`);
-                        fs.writeFileSync(testPath, express5Code);
-                        try {
-                            timeout = setTimeout(() => timeoutFunc('express5'), 60000);
-                            express5Output = (await exec(`node ${testPath}`, {maxBuffer: 1024 * 1024 * 100})).stdout;
-                            clearTimeout(timeout);
-                        } catch(e) {
-                            clearTimeout(timeout);
-                            express5Error = e;
+                        if (marker !== 'SKIP_V5') {
+                            const express5Code = testCode.replace(`const express = require("express");`, `const express = require("express5");`);
+                            fs.writeFileSync(testPath, express5Code);
+                            try {
+                                timeout = setTimeout(() => timeoutFunc('express5'), TEST_TIMEOUT);
+                                express5Output = await execTest(testPath);
+                                clearTimeout(timeout);
+                            } catch(e) {
+                                clearTimeout(timeout);
+                                express5Error = e;
+                            }
+                        } else {
+                            t.diagnostic('express5: SKIPPED');
                         }
 
                         // Run with ultimate-express
@@ -81,20 +97,28 @@ for (const testCategory of testCategories) {
                             throw new Error("Test code does not contain require express");
                         }
                         fs.writeFileSync(testPath, newCode);
-                        timeout = setTimeout(() => timeoutFunc('ultimate-express'), 60000)
-                        let uExpressOutput = (await exec(`node ${testPath}`, {maxBuffer: 1024 * 1024 * 100})).stdout;
+                        timeout = setTimeout(() => timeoutFunc('ultimate-express'), TEST_TIMEOUT)
+                        let uExpressOutput = await execTest(testPath);
                         clearTimeout(timeout);
 
-                        // Compare with Express 4 (strict)
-                        assert.strictEqual(uExpressOutput, expressOutput);
-
-                        // Compare with Express 5 (diagnostic)
-                        if(express5Error) {
-                            t.diagnostic(`express5: ERROR - ${(express5Error.stderr || express5Error.message || String(express5Error)).split('\n')[0]}`);
-                        } else if(uExpressOutput === express5Output) {
-                            t.diagnostic('express5: PASS');
+                        // Compare outputs
+                        if (marker === 'SKIP_V4') {
+                            // Strict compare against Express 5
+                            assert.strictEqual(uExpressOutput, express5Output);
                         } else {
-                            t.diagnostic('express5: MISMATCH');
+                            // Strict compare against Express 4 (default + SKIP_V5)
+                            assert.strictEqual(uExpressOutput, express4Output);
+                        }
+
+                        // Compare with Express 5 (diagnostic, only when Express 5 ran)
+                        if (marker !== 'SKIP_V5' && marker !== 'SKIP_V4') {
+                            if(express5Error) {
+                                t.diagnostic(`express5: ERROR - ${(express5Error.stderr || express5Error.message || String(express5Error)).split('\n')[0]}`);
+                            } else if(uExpressOutput === express5Output) {
+                                t.diagnostic('express5: PASS');
+                            } else {
+                                t.diagnostic('express5: MISMATCH');
+                            }
                         }
                     } catch (error) {
                         throw error;

--- a/tests/index.js
+++ b/tests/index.js
@@ -42,8 +42,14 @@ for (const testCategory of testCategories) {
             fs.writeFileSync(testPath, testCode);
             let testDescription = testCode.split('\n')[0].slice(2).trim();
 
-            const lastToken = testDescription.split(' ').pop();
-            const marker = ['SKIP_V4', 'SKIP_V5', 'OFF'].includes(lastToken) ? lastToken : null;
+            const secondLine = (testCode.split('\n')[1] || '').trim();
+            let marker = null;
+            let skipReason = null;
+            const markerMatch = secondLine.match(/^\/\/\s*(SKIP_V4|SKIP_V5|OFF)(?::\s*(.*))?$/);
+            if (markerMatch) {
+                marker = markerMatch[1];
+                skipReason = markerMatch[2] || null;
+            }
 
             await new Promise(resolve => {
                 test(testDescription, async (t) => {
@@ -70,7 +76,7 @@ for (const testCategory of testCategories) {
                             express4Output = await execTest(testPath);
                             clearTimeout(timeout);
                         } else {
-                            t.diagnostic('express4: SKIPPED');
+                            t.diagnostic(skipReason ? `express4: SKIPPED (${skipReason})` : 'express4: SKIPPED');
                         }
 
                         // Run with Express 5 (skip if SKIP_V5)
@@ -88,7 +94,7 @@ for (const testCategory of testCategories) {
                                 express5Error = e;
                             }
                         } else {
-                            t.diagnostic('express5: SKIPPED');
+                            t.diagnostic(skipReason ? `express5: SKIPPED (${skipReason})` : 'express5: SKIPPED');
                         }
 
                         // Run with ultimate-express

--- a/tests/tests/app/app-delete.js
+++ b/tests/tests/app/app-delete.js
@@ -1,4 +1,5 @@
 // must support app.delete() and app.del()
+// SKIP_V5: app.del() removed in Express 5
 
 const express = require("express");
 

--- a/tests/tests/app/app-param-deprecated.js
+++ b/tests/tests/app/app-param-deprecated.js
@@ -1,4 +1,5 @@
 // must support app.param() with deprecated callback syntax (function as first argument)
+// SKIP_V5: deprecated callback syntax removed in Express 5
 
 const express = require("express");
 


### PR DESCRIPTION
Add support for per-version skip markers in the test runner, allowing individual tests to skip execution against a specific Express version (v4 or v5) while still running the remaining comparisons.

## Motivation

Some tests exercise features that are removed or fundamentally changed in Express 5 (e.g. `app.del()`, deprecated `app.param()` callback syntax). These tests crash Express 5 with an ERROR, adding noise to the test output. We want to skip only the problematic version and still validate against the other.

## Implementation

The marker is read from the **second line** of each test file as a comment:

```javascript
// must support app.delete() and app.del()
// SKIP_V5: app.del() removed in Express 5
```

### Supported markers

| Marker | Effect |
|--------|--------|
| `SKIP_V5: reason` | Skip Express 5 execution, compare ultimate-express strictly against Express 4 |
| `SKIP_V4: reason` | Skip Express 4 execution, compare ultimate-express strictly against Express 5 |
| `OFF: reason` | Skip the entire test (`t.skip()`) |

### Diagnostic output

When a version is skipped, the runner emits a diagnostic with the reason:

```
# express5: SKIPPED (app.del() removed in Express 5)
```

### Behavior

- Only the second line is checked for markers SKIP_V4, SKIP_V5 and OFF (regex: `^\/\/\s*(SKIP_V4|SKIP_V5|OFF)(?::\s*(.*))?$`)
- Case-sensitive matching
- Tests without a marker on line 2 run all three versions as before (backward compatible)
- The reason after `:` is optional but recommended for documentation

## Test changed

- `tests/tests/app/app-delete.js` — annotated with `SKIP_V5`
- `tests/tests/app/app-param-deprecated.js` — annotated with `SKIP_V5`