### PR TITLE
fix issues with complex multi-param

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -174,7 +174,7 @@ module.exports = class Router extends EventEmitter {
             }
             routes.push(route);
             // normal routes optimization
-            if(canBeOptimized(route.path) && route.pattern !== '/*' && !this.parent && this.get('case sensitive routing') && this.uwsApp) {
+            if(!route.complex && canBeOptimized(route.path) && !this.parent && this.get('case sensitive routing') && this.uwsApp) {
                 if(supportedUwsMethods.has(method)) {
                     const optimizedPath = this._optimizeRoute(route, this._routes);
                     if(optimizedPath) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,14 +52,25 @@ function patternToRegex(pattern, isPrefix = false) {
     }
 
     let wildcardIndex = 0;
-    let regexPattern = pattern
-        .replaceAll('.', '\\.')
-        .replaceAll('-', '\\-')
-        .replaceAll(/(\*|\(.*?\))/g, (match) => `(?<_wc${wildcardIndex++}>${match.startsWith('(') ? match.slice(1, -1) : match.replaceAll('*', '.*')})`) // Convert * to .* and stuff in parentheses to capture group
-        .replace(/\/:(\w+)(\(.+?\))?\??/g, (match, param, regex) => {
-            const optional = match.endsWith('?');
-            return `\\/${optional ? '?' : ''}(?<${param}>${regex ? regex + '($|\\/)' : '[^/]+'})${optional ? '?' : ''}`;
-        }); // Convert :param to capture group
+    let regexPattern = '';
+    const captureGroupTest = /(\/|[.-]+):(\w+)(?:\((.+?)\))?\??/g;
+    let offset = 0;
+    while (true) {
+        const result = captureGroupTest.exec(pattern);
+        // Process last preceding part if matched, or final part if match ended
+        regexPattern += pattern.substring(offset, result?.index ?? pattern.length)
+            .replaceAll('.', '\\.')
+            .replaceAll('-', '\\-')
+            .replaceAll(/(\*|\(.*?\))/g, (match) => // Convert * to .* and stuff in parentheses to capture group
+                `(?<_wc${wildcardIndex++}>${match.startsWith('(') ? match.slice(1, -1) : match.replaceAll('*', '.*')})`
+        );
+        if (!result) break;
+        const [match, prefix, param, regex] = result;
+        const optional = match.endsWith('?');
+        // Convert :param to capture group
+        regexPattern += `${optional ? '(' : ''}${prefix}(?<${param}>${regex ? regex + '(?=$|\/)' : '[^/]+'})${optional ? ')?' : ''}`;
+        offset = result.index + match.length;
+    }
 
     return new RegExp(`^${regexPattern}${isPrefix ? '(?=$|\/)' : '$'}`);
 }

--- a/tests/tests/routers/multi-params.js
+++ b/tests/tests/routers/multi-params.js
@@ -4,12 +4,20 @@ const express = require("express");
 
 const app = express();
 
+app.get("/api/1.0/info/:subdir(ab|cd)?/:item([0-9A-Za-z-_]{6}.[^.])/:empty(.{0})?/details", (req, res) => {
+    res.json({path: req.path, params: req.params});
+});
+
 app.get("/api/1.0/projects/:project_id/user/:user_id", (req, res) => {
     res.json({path: req.path, params: req.params});
 });
 
 app.get("/api/1.0/projects/:project_id/users", (req, res) => {
     res.json({path: req.path, params: req.params});
+});
+
+app.use((req, res, next) => {
+     res.send('404');
 });
 
 app.listen(13333, async () => {
@@ -20,6 +28,21 @@ app.listen(13333, async () => {
             res.json()
         ),
         fetch("http://localhost:13333/api/1.0/projects/456/user/789").then((res) =>
+            res.json()
+        ),
+        fetch("http://localhost:13333/api/1.0/info/AAAAAA.2//details").then((res) =>
+            res.json()
+        ),
+        fetch("http://localhost:13333/api/1.0/info/zzzzzz+2//details").then((res) =>
+            res.json()
+        ),
+        fetch("http://localhost:13333/api/1.0/info/ab/Ab_23-+$/details").then((res) =>
+            res.json()
+        ),
+        fetch("http://localhost:13333/api/1.0/info/cd//AAAAAA.a///details").then((res) =>
+            res.json()
+        ),
+        fetch("http://localhost:13333/api/1.0/info/Ab%20c.+//details").then((res) =>
             res.json()
         ),
     ]);

--- a/tests/tests/routing/special-characters.js
+++ b/tests/tests/routing/special-characters.js
@@ -12,6 +12,10 @@ app.get('/hi-bye*a', (req, res) => {
     res.send('hi-bye');
 });
 
+app.get('/test/:from--:to', (req, res) => {
+    res.send(`from: ${req.params.from}, to: ${req.params.to}`);
+});
+
 app.listen(13333, async () => {
     console.log('Server is running on port 13333');
 
@@ -22,6 +26,9 @@ app.listen(13333, async () => {
     console.log(await res.text());
 
     res = await fetch('http://localhost:13333/test/hiAbyeaa');
+    console.log(await res.text());
+    
+    res = await fetch('http://localhost:13333/test/123--xyz');
     console.log(await res.text());
 
     process.exit(0);


### PR DESCRIPTION
This PR fixes multiple issues with the current matching strategy with regards to multi-param routes:

 - Regex in named capture groups is treated as patterns, breaking for `-` and `.` as they are not meant verbatim there
 - Regex handling is incompatible with multi-param (resulting in an extra slash)
 - Regex in named capture groups processed twice (first as pattern) resulting in both indexed and named params, breaking exact match with Express
 - Paths with named params without regex are still complex (implicit `([^/]+)`), but are wrongly optimized (happening in app but not router, which confused me a lot initially)

The ideas come from my personal use case and the official Express.js 4.x documentation, with the official `path-to-regexp` 0.1.x as a loose reference.

Not sure if the test cases are okay like this (may need to reorganize), but they definitely serve the purpose of identifying the exact problems with the current implementation.