### PR TITLE
Fix static files under 768KB 404ing behind express-session (worker returns ArrayBuffer)

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -40,7 +40,10 @@ class FSWorker {
             if(message.err) {
                 workerTasks[message.key].reject(new Error(message.err));
             } else {
-                workerTasks[message.key].resolve(message.data);
+                // worker transfers file contents as an ArrayBuffer; wrap it in a Buffer (zero-copy) so
+                // consumers get the same type as fs.readFile. A bare ArrayBuffer is rejected by wrapped
+                // res.end() implementations (e.g. express-session calls Buffer.byteLength on the chunk).
+                workerTasks[message.key].resolve(message.data instanceof ArrayBuffer ? Buffer.from(message.data) : message.data);
             }
             delete workerTasks[message.key];
         });

--- a/tests/tests/middlewares/express-static-session.js
+++ b/tests/tests/middlewares/express-static-session.js
@@ -1,0 +1,39 @@
+// must serve static files under 768KB when res.end is wrapped by express-session
+
+const express = require("express");
+const session = require("express-session");
+
+// force the non-optimized dispatch path (the uWS route optimizer masks this bug),
+// and route small files through the file worker (default on multi-core machines)
+function makeApp(options, useSession) {
+    const app = options ? express(options) : express();
+    app.set("case sensitive routing", false);
+    if(useSession) {
+        app.use(session({ secret: "x", resave: false, saveUninitialized: true }));
+    }
+    app.use("/static", express.static("tests/parts"));
+    app.use((req, res) => {
+        res.status(404).send("catchall");
+    });
+    return app;
+}
+
+async function check(label, app, port, file) {
+    await new Promise(resolve => app.listen(port, resolve));
+    await new Promise(resolve => setTimeout(resolve, 200)); // wait past the optimizer window
+    const res = await fetch(`http://localhost:${port}/static/${file}`);
+    const body = await res.text();
+    console.log(label, res.status, body.length);
+}
+
+(async () => {
+    // small file (< 768KB): worker path. With default threads on multi-core, this is the bug.
+    await check("default+session small", makeApp(undefined, true), 13334, "index.ejs");
+    // control: no workers, so the pipe path is used
+    await check("threads0+session small", makeApp({ threads: 0 }, true), 13335, "index.ejs");
+    // control: without session, an unwrapped end() accepts the worker result
+    await check("default nosession small", makeApp(undefined, false), 13336, "index.ejs");
+    // control: file > 768KB is streamed, bypassing the worker
+    await check("default+session large", makeApp(undefined, true), 13337, "big.jpg");
+    process.exit(0);
+})();


### PR DESCRIPTION
## Practical impact

On any **multi-core** host with **default settings**, every static file **smaller than 768KB** mounted **after `express-session`** (or any middleware that wraps `res.end`, e.g. passport) returns **404**, even though the file exists on disk and is readable. Statics mounted *before* the session middleware work, which is why this hides in development and small apps.

## Cause

ultimate-express defaults `threads = 1` on multi-core hosts and serves files under 768KB through the file worker (`response.js`, `sendFile`). The worker transfers file contents as an **ArrayBuffer** (`src/worker.js`). ultimate-express's own `res.end()` accepts an ArrayBuffer, so a bare app serves the file fine. But when `res.end` has been wrapped per-request — express-session wraps it and calls `Buffer.byteLength(chunk)` to set `Content-Length` — the ArrayBuffer is rejected:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type
string or an instance of Buffer, TypedArray, or DataView.
Received an instance of ArrayBuffer
```

That rejection lands in `sendFile`'s `.catch`, which calls the static middleware's fallthrough `next()`; the request falls through to the outer 404 handler.

## Repro

```js
const express = require('ultimate-express');
const session = require('express-session');
const app = express();                       // threads defaults to 1 on multi-core
app.set('case sensitive routing', false);    // force normal dispatch
app.use(session({ secret: 'x', resave: false, saveUninitialized: true }));
app.use('/assets', express.static(DIR_WITH_A_SMALL_FILE));
app.use((req, res) => res.status(404).send('catchall'));
app.listen(3000, async () => {
  await new Promise(r => setTimeout(r, 200));
  const res = await fetch('http://127.0.0.1:3000/assets/small.js');
  console.log(res.status); // ultimate-express: 404, express: 200
});
```

## Fix

Wrap the worker result in a `Buffer` (zero-copy) at the `readFileWithWorker` resolve boundary, so the helper returns the same type as `fs.readFile` — which every express-compatible `end()` wrapper accepts. It is the only consumer of the worker read, and the conversion is a no-op for any already-Buffer value.

## Tests

New `tests/tests/middlewares/express-static-session.js` with controls: default threads + session (the bug), `threads: 0` + session (pipe path), default threads without session (unwrapped `end` accepts the ArrayBuffer — why it hides), and a >768KB file (stream path bypasses the worker). Fails on master, passes with the fix, output identical to express 4 and 5. Full suite passes (only the unrelated `app-cluster.js` / port-3000 environmental failure).

## Context

Found integrating `@bull-board/express`'s sub-app on a production Express 5-style stack; verified against real express 5.2.1.
