### PR TITLE
Fix res.render using the outer app's views for mounted sub-apps

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -679,7 +679,8 @@ module.exports = class Response extends Writable {
             this.send(str);
         });
 
-        this.app.render(view, options, done);
+        // use req.app like express does, so mounted sub-apps resolve views with their own settings
+        this.req.app.render(view, options, done);
     }
     cookie(name, value, options) {
         const opt = {...(options ?? {})}; // create a new ref because we change original object (https://github.com/dimdenGD/ultimate-express/issues/68)

--- a/src/router.js
+++ b/src/router.js
@@ -241,7 +241,9 @@ module.exports = class Router extends EventEmitter {
                             [...chainPrefix, ...pathToMount, {
                                 ...route,
                                 callbacks: [],
-                                keepMount: true
+                                keepMount: true,
+                                // mounted sub-apps become req.app during their dispatch, like express
+                                mountApp: route.callbacks[0].constructor.name === 'Application' ? route.callbacks[0] : undefined
                             }]
                         );
                     }
@@ -495,6 +497,7 @@ module.exports = class Router extends EventEmitter {
                 return false;
             }
             // on optimized routes, there can be more routes, so we have to use unoptimized routing and skip until we find route we stopped at
+            req.app = this; // restore app in case the optimized path swapped it to a mounted sub-app
             return this._routeRequest(req, res, 0, this._routes, false, skipUntil);
         }
         let callbackindex = 0;
@@ -507,6 +510,11 @@ module.exports = class Router extends EventEmitter {
         
         const strictRouting = this.get('strict routing');
         if(route.use) {
+            if(route.mountApp) {
+                // optimized chain: normal dispatch swaps req.app when it enters a mounted Application,
+                // but the compiled mount route has no callback to do it, so swap it here
+                req.app = route.mountApp;
+            }
             req._stack.push(route.path);
             const fullMountpath = this.getFullMountpath(req);
             req._opPath = fullMountpath !== EMPTY_REGEX ? req._originalPath.replace(fullMountpath, '') : req._originalPath;

--- a/tests/parts/subapp/index.ejs
+++ b/tests/parts/subapp/index.ejs
@@ -1,0 +1,2 @@
+<h1>subapp <%= message %></h1>
+<span><%= asdf %></span>

--- a/tests/tests/res/res-render-subapp.js
+++ b/tests/tests/res/res-render-subapp.js
@@ -1,0 +1,50 @@
+// res.render must use the views and engine of the sub-app handling the request
+
+const express = require("express");
+
+const app = express();
+app.set('view engine', 'ejs');
+app.set('views', 'tests/parts');
+app.set('env', 'production');
+
+const subApp = express();
+subApp.set('view engine', 'ejs');
+subApp.set('views', 'tests/parts/subapp');
+subApp.set('env', 'production');
+
+subApp.get('/page', (req, res) => {
+    res.locals.asdf = 'locals test';
+    res.render('index.ejs', { message: 'from subapp' });
+});
+
+subApp.get('/fallthrough', (req, res, next) => {
+    next();
+});
+
+app.use('/sub', subApp);
+
+app.use((req, res) => {
+    res.locals.asdf = 'locals test';
+    res.render('index.ejs', { title: 'Outer', message: 'from outer' });
+});
+
+app.use((err, req, res, next) => {
+    console.log(err.message.split('\n')[0]);
+    res.status(500).send('whoops!');
+});
+
+app.listen(13333, async () => {
+    console.log('Server is running on port 13333');
+
+    // before the router optimization kicks in
+    console.log(await fetch('http://localhost:13333/sub/page').then(res => res.text()));
+    console.log(await fetch('http://localhost:13333/sub/fallthrough').then(res => res.text()));
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    // after the router optimization kicks in
+    console.log(await fetch('http://localhost:13333/sub/page').then(res => res.text()));
+    console.log(await fetch('http://localhost:13333/sub/fallthrough').then(res => res.text()));
+
+    process.exit(0);
+});


### PR DESCRIPTION
## Problem

A mounted sub-app's `res.render` should resolve views with the sub-app's own `views` / `view engine` / `engine()` settings — express does this by looking up `this.req.app` in `res.render`, and `req.app` points at the sub-app during its dispatch. ultimate-express instead calls `this.app.render(...)`, and `res.app` is fixed at response construction to the **outer** app, so a mounted sub-app's view configuration was ignored and rendering failed with `Failed to lookup view ... in views directory <outer app's ./views>` (or `No default engine was specified` when the outer app has no view config).

## Repro

```js
const express = require("ultimate-express");
const outer = express();
const sub = express();
sub.set("views", "/dir/with/index.ejs");
sub.set("view engine", "ejs");
sub.engine("ejs", require("ejs").renderFile);
sub.get("/page", (req, res) => res.render("index"));
outer.use("/sub", sub);
outer.listen(3000);
// GET /sub/page -> express renders; ultimate-express throws the lookup error
```

Verified side by side against express 4 and express 5.2.x.

## Fix

1. `res.render` now delegates to `this.req.app.render(...)`, matching express.
2. The route optimizer's compiled chain (`_compileOptimizedRoutes`) now records the mounted **Application** on the compiled mount route (`mountApp`) and `_routeRequest` swaps `req.app` to it during dispatch — normal dispatch already swaps `req.app` when it enters a mounted Application, but the compiled mount route has no callback to do so.
3. On fallthrough from an exhausted optimized path back to normal routing, `req.app` is restored to the top-level app, so a sub-app route that calls `next()` into an outer handler doesn't leak the sub-app's config.

This is rebased on top of the `refactor route optimization` commit, and (2) is implemented in that new compiled-chain mechanism rather than the old `setTimeout`-based path.

## Tests

New `tests/tests/res/res-render-subapp.js` (+ fixture `tests/parts/subapp/index.ejs`): a sub-app with its own `views` dir mounted on an outer app with a different `views` dir, rendering via the sub-app, plus a fallthrough case where the sub-app `next()`s into an outer catch-all that renders with the outer app's config. Output matches express 4 and express 5; full suite passes (the only failing test, `app-cluster.js`, fails identically on a clean checkout here — an unrelated process holds port 3000).

## Context

Found integrating `@bull-board/express`'s sub-app (which sets its own views/engine) behind an outer app on a production Express 5-style stack.
