### PR TITLE
Fix error thrown in a mounted router routing to a pre-mount error handler (#239)

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -315,7 +315,13 @@ module.exports = class Router extends EventEmitter {
                     request.optimizedParams[route.optimizedParams[i]] = req.getParameter(i);
                 }
             }
-            const skipUntil = optimizedPath.length ? optimizedPath[optimizedPath.length - 1] : route;
+            // for a route optimized through a mounted router, falling back to normal routing must resume
+            // after the mount in the parent (like normal dispatch does), not after the router's leaf route.
+            // the leaf can have a lower routeKey than the parent's own middlewares (e.g. when the router is
+            // required from another module), which would otherwise let a pre-mount error handler catch an
+            // error thrown inside the router.
+            const mount = optimizedPath.find(r => r.keepMount);
+            const skipUntil = mount ?? (optimizedPath.length ? optimizedPath[optimizedPath.length - 1] : route);
             const matchedRoute = await this._routeRequest(request, response, 0, optimizedPath, true, skipUntil);
             if(!matchedRoute && !response.headersSent && !response.aborted) {
                 if(request._error) {
@@ -498,6 +504,12 @@ module.exports = class Router extends EventEmitter {
             }
             // on optimized routes, there can be more routes, so we have to use unoptimized routing and skip until we find route we stopped at
             req.app = this; // restore app in case the optimized path swapped it to a mounted sub-app
+            // an error that propagated out of a mounted router's optimized chain is attributed to the mount
+            // (like normal dispatch does when a sub-router returns an error), so parent error handlers declared
+            // before the mount don't catch it - the router's leaf can have a lower routeKey than those handlers
+            if(req._error && skipUntil && skipUntil.keepMount && skipUntil.routeKey > req._errorKey) {
+                req._errorKey = skipUntil.routeKey;
+            }
             return this._routeRequest(req, res, 0, this._routes, false, skipUntil);
         }
         let callbackindex = 0;

--- a/tests/tests/routers/mounted-router-error-handler-order.js
+++ b/tests/tests/routers/mounted-router-error-handler-order.js
@@ -1,0 +1,48 @@
+// must run the error handler declared after a mounted router, not one before it
+
+const express = require("express");
+
+// router defined before the parent's middlewares, so its routes get lower routeKeys
+// (this is what happens when a router is required from another module)
+const router = express.Router();
+router.post("/path", function handler(req, res) {
+    throw new Error("Whoops");
+});
+router.get("/ok", function ok(req, res) {
+    res.send("ok");
+});
+
+const app = express();
+app.use(express.json());
+app.set("catch async errors", true);
+
+app.use(function jsonErrorHandler(err, req, res, next) {
+    if(err) {
+        return res.send("JSON error");
+    }
+    next();
+});
+
+app.use("/route", router);
+
+app.use(function errorHandler(err, req, res, next) {
+    if(err) {
+        return res.json(err.toString());
+    }
+    next();
+});
+
+app.listen(13333, async () => {
+    console.log("Server is running on port 13333");
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // error thrown in the router must reach the error handler declared AFTER the mount
+    let res = await fetch("http://localhost:13333/route/path", { method: "POST" });
+    console.log(res.status, await res.text());
+
+    // a normal route in the same router still works
+    res = await fetch("http://localhost:13333/route/ok");
+    console.log(res.status, await res.text());
+
+    process.exit(0);
+});


### PR DESCRIPTION
Fixes #239.

## Problem

An error thrown inside a router mounted with `app.use(path, router)` should be caught by an error handler declared **after** the mount (as express does), not one declared before it. ultimate-express routed it to the handler declared **before** the mount:

```js
// router.js
const router = require("ultimate-express").Router();
router.post("/path", (req, res) => { throw new Error("Whoops"); });
module.exports = router;

// index.js
const app = express();
app.use(function jsonErrorHandler(err, req, res, next) { if (err) return res.send("JSON error"); next(); });
app.use("/route", require("./router"));
app.use(function errorHandler(err, req, res, next) { if (err) return res.json(err.toString()); next(); });
app.listen(3000);
// POST /route/path -> express: "Error: Whoops"  |  ultimate-express: "JSON error"
```

The reporters noted it was flaky and only happened when the router was imported from another module. Both observations follow from the cause below; verified against express 4 and express 5.2.x.

## Cause

The route optimizer replays a mounted router's leaf route inline in the parent's uWS fast-path chain. Normal dispatch attributes an error propagating out of a sub-router to the **mount** (`req._errorKey = <mount route key>` after the sub-router returns), but the optimized chain never did this, so `req._errorKey` kept the **leaf** route's key.

A router's routes get a lower `routeKey` than the parent's own middlewares when the router is constructed before them — which is exactly what happens when it is `require`d from another module. An error handler is selected when `route.routeKey >= req._errorKey`, so a pre-mount handler (key higher than the leaf's) wrongly qualified. "Flaky / only from another module" is this ordering; "only sometimes" was the old ~100ms optimizer window (now compiled at `listen`, so it is consistent).

## Fix

When the optimized chain is exhausted and dispatch falls back to normal routing, attribute a pending error to the mount's `routeKey` (mirroring normal dispatch), and make `skipUntil` the mount boundary rather than the router's leaf so fallthrough resumes after the mount instead of re-running the parent middlewares that precede it. Both are gated on the chain actually crossing a mounted router (the `keepMount` marker), so plain top-level optimized routes are unaffected.

## Test

New `tests/tests/routers/mounted-router-error-handler-order.js`: a router defined before the parent's handlers (reproducing the lower-`routeKey` condition in a single file), with an error-throwing route and a normal route. Fails on `main`, passes with the fix, output identical to express 4 and express 5. Full suite passes.
