### PR TITLE
perf: skip full headers build in req.fresh when no conditional headers

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -321,6 +321,28 @@ module.exports = class Request extends Readable {
             return false;
         }
         if((this.res.statusCode >= 200 && this.res.statusCode < 300) || this.res.statusCode === 304) {
+            // fast path: res.end() reads req.fresh on every response, but fresh() can only
+            // return true when the request carries a conditional header. Scan the raw entries
+            // instead of materializing the full headers object, which is lazy by design.
+            // Only valid while headers are untouched: both the getter and the setter populate #cachedHeaders.
+            if(this.#cachedHeaders === null) {
+                let hasConditional = false;
+                const entries = this.#rawHeadersEntries;
+                for(let i = 0, len = entries.length; i < len; i++) {
+                    const key = entries[i][0];
+                    // 'if-none-match'.length === 13, 'if-modified-since'.length === 17
+                    if(key.length === 13 || key.length === 17) {
+                        const lower = key.toLowerCase();
+                        if(lower === 'if-none-match' || lower === 'if-modified-since') {
+                            hasConditional = true;
+                            break;
+                        }
+                    }
+                }
+                if(!hasConditional) {
+                    return false;
+                }
+            }
             return fresh(this.headers, {
                 'etag': this.res.headers['etag'],
                 'last-modified': this.res.headers['last-modified'],


### PR DESCRIPTION
`res.end()` reads `req.fresh` on every response; for any GET/HEAD 2xx this materialized the entire lazy headers object just for `fresh()` to return false when the client sent no if-none-match/if-modified-since (the overwhelmingly common case). Scan the raw header entries first and only fall through to the full path when a conditional header is present or `req.headers` was already materialized/replaced.

express-static (+71%) and compression-file (+46%): sendFile() has check if(this.req.fresh) at response.js:527
hello-world (+24%)

MASTER (LATEST COMMIT)

| Test | Express req/sec | uExpress req/sec | Express throughput | uExpress throughput | uExpress speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| engines/art | 8.70k | 19.49k | 3.82 MB/sec | 8.57 MB/sec | **2.24x** |
| middlewares/body-urlencoded | 13.78k | 48.40k | 2.14 MB/sec | 7.57 MB/sec | **3.54x** |
| middlewares/compression-file | 7.17k | 9.34k | 3.27 MB/sec | 4.27 MB/sec | **1.31x** |
| middlewares/express-static | 3.68k | 5.04k | 901.12 MB/sec | 1.20 GB/sec | **1.36x** |
| routing/hello-world | 18.65k | 116.39k | 3.09 MB/sec | 19.42 MB/sec | **6.28x** |
| routing/middlewares-100 | 15.07k | 21.03k | 2.36 MB/sec | 3.31 MB/sec | **1.40x** |
| routing/nested-routers | 18.84k | 91.79k | 3.02 MB/sec | 14.79 MB/sec | **4.90x** |
| routing/routes-1000 | 4.27k | 78.28k | 683.46 KB/sec | 12.32 MB/sec | **18.46x** |
| streaming/readable-hash-4mb | 18.60k | 105.96k | 6.88 MB/sec | 39.31 MB/sec | **5.71x** |
| streaming/writable-no-content-length | 788.32 | 1.07k | 3.85 GB/sec | 5.22 GB/sec | **1.36x** |
| streaming/writable-with-content-length | 1.07k | 1.06k | 5.25 GB/sec | 5.19 GB/sec | **0.99x** |


PR

| Test | Express req/sec | uExpress req/sec | Express throughput | uExpress throughput | uExpress speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| engines/art | 4.04k | 8.13k | 1.77 MB/sec | 3.57 MB/sec | **2.02x** |
| middlewares/body-urlencoded | 5.92k | 20.46k | 942.08 KB/sec | 3.20 MB/sec | **3.48x** |
| middlewares/compression-file | 3.64k | 6.94k | 1.66 MB/sec | 3.17 MB/sec | **1.91x** |
| middlewares/express-static | 2.09k | 4.86k | 510.48 MB/sec | 1.16 GB/sec | **2.33x** |
| routing/hello-world | 7.85k | 60.44k | 1.30 MB/sec | 10.09 MB/sec | **7.76x** |
| routing/middlewares-100 | 7.82k | 12.50k | 1.22 MB/sec | 1.97 MB/sec | **1.61x** |
| routing/nested-routers | 7.98k | 44.13k | 1.28 MB/sec | 7.11 MB/sec | **5.55x** |
| routing/routes-1000 | 3.50k | 39.74k | 560.27 KB/sec | 6.25 MB/sec | **11.42x** |
| streaming/readable-hash-4mb | 8.28k | 47.39k | 3.06 MB/sec | 17.58 MB/sec | **5.75x** |
| streaming/writable-no-content-length | 537.40 | 566.64 | 2.63 GB/sec | 2.77 GB/sec | **1.05x** |
| streaming/writable-with-content-length | 544.95 | 617.26 | 2.66 GB/sec | 3.02 GB/sec | **1.14x** |
