### PR TITLE
fix: stop body parsers from responding twice to an oversized body

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -234,7 +234,15 @@ function createBodyParser(defaultType, beforeReturn) {
 
             req.bodyRead = true;
 
+            // uWS keeps delivering chunks after we reject an oversized body, and the
+            // stream path still emits 'end', so without this every further chunk would
+            // call next() again and the second response would throw
+            let finished = false;
+
             function onData(buf) {
+                if(finished) {
+                    return;
+                }
                 if(!Buffer.isBuffer(buf)) {
                     buf = Buffer.from(buf);
                 }
@@ -247,11 +255,17 @@ function createBodyParser(defaultType, beforeReturn) {
 
                 totalSize += buf.length;
                 if(totalSize > options.limit) {
+                    finished = true;
+                    abs.length = 0;
                     return next(new Error('Request entity too large'));
                 }
             }
-    
+
             function onEnd() {
+                if(finished) {
+                    return;
+                }
+                finished = true;
                 const buf = Buffer.concat(abs);
                 if(options.verify) {
                     try {

--- a/tests/tests/middlewares/body-limit-chunked.js
+++ b/tests/tests/middlewares/body-limit-chunked.js
@@ -1,0 +1,54 @@
+// must reject a chunked body over the limit without responding twice
+
+const express = require("express");
+
+const app = express();
+
+app.use(express.json({ limit: '20b' }));
+
+app.post('/abc', (req, res) => {
+    res.json({ ok: true });
+});
+
+app.use((err, req, res, next) => {
+    res.status(413).json({ tooLarge: true });
+});
+
+app.listen(13333, async () => {
+    console.log('Server is running on port 13333');
+
+    // a streamed body arrives in several chunks and carries no content-length,
+    // so the limit can only be caught while reading
+    const body = new ReadableStream({
+        start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"aaaaaaaaaa":'));
+            controller.enqueue(new TextEncoder().encode('"bbbbbbbbbbbbbbbbbbbb"}'));
+            controller.close();
+        }
+    });
+
+    const response = await fetch('http://localhost:13333/abc', {
+        method: 'POST',
+        body,
+        duplex: 'half',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+
+    console.log(response.status);
+    console.log(await response.text());
+
+    // the server must still be answering after rejecting the oversized body
+    const after = await fetch('http://localhost:13333/abc', {
+        method: 'POST',
+        body: '{"a":1}',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+    console.log(after.status);
+    console.log(await after.text());
+
+    process.exit(0);
+});


### PR DESCRIPTION
Sending a chunked request body larger than a body parser limit crashes the server with an uncaught exception, so any client can take the process down.

### What happens

`onData` calls `next(new Error("Request entity too large"))` as soon as the accumulated size passes the limit, but it keeps being called for every chunk that is still on the way, and the stream path emits `end` afterwards too. Each of those calls runs the error handler again. The first one answers the request, the second one throws `Can't write body: Response was already sent`, and nothing catches it.

A body sent with `content-length` is caught earlier by the header check, so it does not reach this path. A chunked body has no `content-length`, so the limit can only be caught while reading, which is where the repeat calls happen.

### Reproduction

```js
const express = require("ultimate-express");
const app = express();
app.use(express.json({ limit: "20b" }));
app.post("/", (req, res) => res.json({ ok: true }));
app.use((err, req, res, next) => res.status(413).json({ tooLarge: true }));

app.listen(3000, async () => {
    const body = new ReadableStream({
        start(c) {
            c.enqueue(new TextEncoder().encode('{"aaaaaaaaaa":'));
            c.enqueue(new TextEncoder().encode('"bbbbbbbbbbbbbbbbbbbb"}'));
            c.close();
        }
    });
    await fetch("http://127.0.0.1:3000/", {
        method: "POST", body, duplex: "half",
        headers: { "content-type": "application/json" }
    });
});
```

On `main` the server dies with `Error: Can't write body: Response was already sent`. Express 4 and Express 5 answer `413` and stay up.

### Fix

Mark the parse as finished on the first outcome, whether that is the limit being hit or the body ending, and ignore whatever arrives after. The buffered chunks are dropped at the same time, so an oversized body is not held in memory while the error travels through the middleware chain.

### Tests

Added `tests/middlewares/body-limit-chunked.js`, which sends an oversized chunked body and then a normal one to check the server is still answering. It fails on `main` and matches Express 4 and Express 5 output with this change.