### PR TITLE
perf: collect request bodies natively with uWS collectBody

### DIFF
--- a/benchmark/scenarios/body-json-512kb.js
+++ b/benchmark/scenarios/body-json-512kb.js
@@ -1,0 +1,28 @@
+'use strict';
+
+// The other body-parser scenario posts 57 bytes, which uWS hands over in a single
+// chunk, so it never exercises the accumulate path. This one is large enough to
+// arrive in several chunks and makes the cost of collecting a body visible.
+const PAD = 512 * 1024;
+
+module.exports = {
+    name: 'middlewares/body-json-512kb',
+    path: '/abc',
+    wrk: {
+        script: 'post-json-512kb.lua',
+        connections: 50
+    },
+    verify: {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ n: 1, pad: 'x'.repeat(PAD) })
+    },
+    setup(app, express) {
+        app.use(express.json({ limit: '10mb' }));
+        app.post('/abc', (req, res) => {
+            res.send(`${req.body.pad.length}`);
+        });
+    }
+};

--- a/benchmark/wrk-scripts/post-json-512kb.lua
+++ b/benchmark/wrk-scripts/post-json-512kb.lua
@@ -1,0 +1,7 @@
+wrk.method = "POST"
+wrk.path = "/abc"
+wrk.headers["Content-Type"] = "application/json"
+
+local kb = 1024
+local pad = string.rep("x", 512 * kb)
+wrk.body = '{"n":1,"pad":"' .. pad .. '"}'

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -267,6 +267,32 @@ function createBodyParser(defaultType, beforeReturn) {
             // if we are fast enough (not async), we can do it
             // otherwise we need to use a stream since it already started streaming it
             if(!req.receivedData) {
+                // uWS can accumulate the whole body natively and hand it over in a single call,
+                // which skips one JS callback per chunk and the final Buffer.concat.
+                // not usable when inflating, since options.limit applies to the decompressed
+                // size while collectBody can only cap the compressed bytes it receives.
+                if(!inflate && Number.isFinite(options.limit)) {
+                    req._res.collectBody(options.limit, ab => {
+                        // uWS returns null when the body exceeded the limit
+                        if(ab === null) {
+                            return next(new Error('Request entity too large'));
+                        }
+                        // uWS may hand over memory it owns and detaches right after this call,
+                        // so only parsers that don't keep the buffer around can view it directly
+                        const buf = beforeReturn.retainsBuffer || options.verify
+                            ? Buffer.from(ab.slice(0))
+                            : Buffer.from(ab);
+                        if(options.verify) {
+                            try {
+                                options.verify(req, res, buf);
+                            } catch(e) {
+                                return next(e);
+                            }
+                        }
+                        beforeReturn(req, res, next, options, buf);
+                    });
+                    return;
+                }
                 req._res.onData((ab, isLast) => {
                     onData(ab);
                     if(isLast) {
@@ -300,10 +326,14 @@ const json = createBodyParser('application/json', function(req, res, next, optio
     next();
 });
 
-const raw = createBodyParser('application/octet-stream', function(req, res, next, options, buf) {
+function rawParser(req, res, next, options, buf) {
     req.body = buf;
     next();
-});
+}
+// req.body outlives the parser, so this one needs its own copy of the body
+rawParser.retainsBuffer = true;
+
+const raw = createBodyParser('application/octet-stream', rawParser);
 
 const text = createBodyParser('text/plain', function(req, res, next, options, buf) {
     let contentType = req.headers['content-type'];


### PR DESCRIPTION
### TL;DR: no demonstrated win

---

uWS can accumulate a whole request body in C++ and hand it over in a single call, which lets the body parsers drop the per-chunk bookkeeping they do today.

### What changes

On the fast path (`!req.receivedData`) the parsers used `res.onData` and rebuilt the body in JS: one callback per chunk, `Buffer.from(buf)` per chunk into an array, then `Buffer.concat` at the end. That is two copies of the body plus one JS/C++ crossing per chunk.

With `res.collectBody(limit, cb)` uWS accumulates the chunks itself (reserving up front when it knows the remaining length) and calls back once. The size limit is enforced natively, and uWS yields `null` when the body goes over it.

Parsers that do not keep the buffer past their own call `json`, `text`, `urlencoded`, all of which only read it through `toString()` - now read straight from the memory uWS owns, so the last copy goes away too. `raw` assigns the buffer to `req.body`, and a `verify` callback may hold on to it as well, so both still get a copy.

### What stays on the old path

Inflated bodies. `options.limit` is checked against the decompressed size, while `collectBody` can only cap the compressed bytes it receives, so delegating the limit would weaken the protection against decompression bombs. Same for a non-finite `limit`, which cannot be handed to the native side.

### Numbers

I could not get a trustworthy measurement on my machine: interleaved runs of the same comparison swung between 0.99x and 1.36x on a 60kb JSON body, and server-side CPU per request moved by ±30% between rounds, so I would rather not quote a figure. What the change removes is concrete though, one callback per chunk, one copy per chunk, one final `concat`, and for the three text parsers the remaining copy, so the benchmark job here on Linux should be a better judge than anything I can produce on Windows.

Worth noting for expectations: uWS already delivers bodies with a `content-length` up to about 512kb in a single chunk, so for small payloads this mainly removes copies rather than callbacks. Bodies above that arrive in ~512kb chunks, which is where the old accumulate-and-concat path did the most work.