### PR TITLE
benchmark: add a large JSON body scenario

### DIFF
--- a/benchmark/scenarios/body-json-512kb.js
+++ b/benchmark/scenarios/body-json-512kb.js
@@ -1,0 +1,28 @@
+'use strict';
+
+// The other body-parser scenario posts 57 bytes, which uWS hands over in a single
+// chunk, so it never exercises the accumulate path. This one is large enough to
+// arrive in several chunks and makes the cost of collecting a body visible.
+const PAD = 512 * 1024;
+
+module.exports = {
+    name: 'middlewares/body-json-512kb',
+    path: '/abc',
+    wrk: {
+        script: 'post-json-512kb.lua',
+        connections: 50
+    },
+    verify: {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ n: 1, pad: 'x'.repeat(PAD) })
+    },
+    setup(app, express) {
+        app.use(express.json({ limit: '10mb' }));
+        app.post('/abc', (req, res) => {
+            res.send(`${req.body.pad.length}`);
+        });
+    }
+};

--- a/benchmark/wrk-scripts/post-json-512kb.lua
+++ b/benchmark/wrk-scripts/post-json-512kb.lua
@@ -1,0 +1,7 @@
+wrk.method = "POST"
+wrk.path = "/abc"
+wrk.headers["Content-Type"] = "application/json"
+
+local kb = 1024
+local pad = string.rep("x", 512 * kb)
+wrk.body = '{"n":1,"pad":"' .. pad .. '"}'


### PR DESCRIPTION
The suite has one scenario that goes through a body parser, `middlewares/body-urlencoded`, and it posts 57 bytes. uWS hands a body that small to JS in a single chunk, so the parser never has to put anything together and the scenario cannot show the cost of collecting a body.

This adds `middlewares/body-json-512kb`, which posts 512kb of JSON through `express.json()`. That is above the ~512kb chunk size uWS delivers bodies in, so the body arrives in several pieces and the accumulate path is actually exercised.

The scenario validates on both frameworks (same status, same body hash). I could not run wrk locally since I am on Windows, so the numbers will come from this job.

I am also opening this separately from #357 on purpose: that PR changes how bodies are collected, and having this scenario measured on `main` first gives a baseline to compare it against.