### PR TITLE
test: only collect .js files as tests

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -27,7 +27,11 @@ if(filterPath) {
 
 for (const testCategory of testCategories) {
     test(testCategory, async () => {
-        let tests = fs.readdirSync(path.join(__dirname, 'tests', testCategory)).sort((a, b) => parseInt(a) - parseInt(b));
+        // some tests write scratch directories next to themselves, and a leftover one
+        // would otherwise be read as if it were a test file
+        let tests = fs.readdirSync(path.join(__dirname, 'tests', testCategory))
+            .filter(testName => testName.endsWith('.js'))
+            .sort((a, b) => parseInt(a) - parseInt(b));
         for (const testName of tests) {
             if(filterPath && filterPath.endsWith('.js')) {
                 if(path.basename(testName) !== path.basename(filterPath)) {


### PR DESCRIPTION
The runner reads every entry of a category folder and passes it to `readFileSync`, so anything in there that is not a file takes the whole category down with `EISDIR: illegal operation on a directory, read`.

That is easy to end up with. `tests/middlewares/express-fileupload-temp.js` writes to `./tmp`, which resolves against the working directory rather than the test file, so running that test directly from its own folder leaves `tests/tests/middlewares/tmp/` behind. It is covered by the `tmp/` line in `.gitignore`, so it never shows up in `git status` and stays there.

I hit it with a directory left over from February, which made the whole `middlewares` category fail before a single test in it ran.

Filtering to `.js` entries is enough.