### PR TITLE
test: keep the suite runnable on Windows under Node 24+

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -12,6 +12,11 @@ const assert = require("node:assert");
 
 const TEST_TIMEOUT = 60000;
 
+// see tests/win-exit-delay.cjs: without it every test crashes on exit under Node 24+ on Windows
+const NODE_ARGS = process.platform === 'win32'
+    ? `--require "${path.join(__dirname, 'win-exit-delay.cjs')}" `
+    : '';
+
 const testPath = path.join(__dirname, 'tests');
 
 let testCategories = fs.readdirSync(testPath).sort((a, b) => parseInt(a) - parseInt(b));
@@ -65,7 +70,7 @@ for (const testCategory of testCategories) {
                     };
 
                     let execTest = async (testPath) => {
-                        return (await exec(`node ${testPath}`, {maxBuffer: 1024 * 1024 * 100})).stdout
+                        return (await exec(`node ${NODE_ARGS}${testPath}`, {maxBuffer: 1024 * 1024 * 100})).stdout
                     }
 
                     try {

--- a/tests/win-exit-delay.cjs
+++ b/tests/win-exit-delay.cjs
@@ -1,0 +1,19 @@
+// Node 24 and later crash on Windows when process.exit() runs while undici still has
+// keep-alive sockets open: "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING),
+// file src\win\async.c" (nodejs/node#56645). Every test here ends with process.exit()
+// right after fetching, so they hit it, and the crash also loses whatever stdout was
+// still buffered, which makes the captured output unreliable on top of the exit code.
+//
+// Letting the loop settle first avoids it. Preloaded by tests/index.js on win32 only,
+// so nothing changes on Linux or macOS.
+
+const EXIT_DELAY_MS = 100;
+
+const realExit = process.exit.bind(process);
+
+process.exit = (code) => {
+    if (code !== undefined) {
+        process.exitCode = code;
+    }
+    setTimeout(() => realExit(process.exitCode), EXIT_DELAY_MS);
+};


### PR DESCRIPTION
Running `npm test` on Windows with Node 24 or later fails every single test, whatever the code does.

### Why

Each test ends with `process.exit()` right after fetching. On Windows, Node 24 and later trip a libuv assertion when that happens while undici still holds keep-alive sockets:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
```

The process dies with exit code 3221226505, and since the harness runs tests through `exec()`, that rejects and the test is reported as failed even though it did its work correctly. The crash also drops whatever stdout was still buffered, so the captured output is unreliable on top of the exit code, and comparisons against Express can silently be made against truncated text.

It is not this project: it reproduces with plain `http` and no Express or uWS at all.

```js
const http = require("http");
const s = http.createServer((req, res) => res.end("ok"));
s.listen(13399, async () => {
    for (let i = 0; i < 3; i++) await fetch("http://localhost:13399/").then(r => r.text());
    process.exit(0);
});
```

Node 20.14 and 22.13 are fine, 24.0.2, 24.16, 25.0, 25.9 and 26.3 all crash on every run here. Upstream issue: [nodejs/node#56645](https://github.com/nodejs/node/issues/56645).

### Fix

Preload a module on win32 that lets the loop settle before exiting for real. Linux and macOS, and therefore CI, do not load it and are untouched.

I measured the delay rather than guessing: 10ms still crashed 8 times out of 8, 50ms once out of 8, 100ms zero out of 8, so 100ms it is.

The tests that call `process.exit()` do it as their last statement, except `events/event-finished.js`, which calls it inside a `finish` handler where nothing follows either, so delaying it does not let anything extra run.

### Result

Before: every test fails.

After, on Windows with Node 26.3: **300 tests, 298 pass, 2 fail**. All categories pass except `middlewares`, which fails on `multer.js` and takes the category with it.

That multer failure is a separate, pre-existing problem, not something this change causes: on `main` its 200kb multipart upload fails with ECONNRESET 6 times out of 6 on Windows, while the same upload against Express 4 succeeds every time. It passes in CI, so it looks Windows-specific. I could not pin it down: a 200kb upload consumed with `req.on("data")`, with `req.pipe()`, or through `express.raw()` all work, with and without `content-length`, and so does the same FormData request when consumed by hand rather than by multer. Worth its own issue.