### PR TITLE
docs: note the minimum request body throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ app.listen(3000, () => {
 
 - This also applies to non-SSL HTTP too. Do not create http server manually, use `app.listen()` instead.
 - Node.JS max header size is 16384 bytes, while uWebSockets by default is 4096 bytes, so if you need longer headers set the env variable `UWS_HTTP_MAX_HEADERS_SIZE` to max byte count you need.
+- uWebSockets drops a request whose body arrives slower than 16KB/s (10 second idle timeout, not configurable), while Node.JS waits indefinitely, so uploads over very slow connections can fail where Express would accept them.
 
 ## Performance tips
 


### PR DESCRIPTION
uWS requires a request body to keep arriving at 16KB/s or better: `HttpContext.h` only resets the 10 second idle timeout once it has seen another `HTTP_RECEIVE_THROUGHPUT_BYTES * HTTP_IDLE_TIMEOUT_S` bytes, which is 160KB. A slower upload gets its socket reset mid-request, where Express waits for it.

Measured, with no framework specifics involved:

| | result |
| --- | --- |
| ultimate-express, body stalled 5s | 200 |
| ultimate-express, body stalled 12s | fails after 11.8s |
| Express 4, body stalled 12s | 200 after 12.0s |

This is uWS refusing to hold sockets open for slow clients rather than a bug, and it is not reachable from JS (the `idleTimeout` in the bindings is for WebSockets), so a line in the docs seemed like the useful thing to do.

Found while tracking down the flaky multer test in #362.