### PR TITLE
benchmark: add scenarios for the request shapes the suite never covered

### DIFF
--- a/benchmark/scenarios/api-endpoint.js
+++ b/benchmark/scenarios/api-endpoint.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// The suite had no scenario shaped like an actual API endpoint: `grep -r "res.json\|req.params\|req.query"`
+// over benchmark/scenarios returned nothing. That is the most common request shape in an Express
+// application, and the one where the framework's own work is a meaningful share of the request
+// rather than a rounding error next to zlib or JSON.parse.
+module.exports = {
+    name: 'routing/api-endpoint',
+    path: '/api/users/42/posts?fields=id,title,author&limit=10',
+    setup(app, express) {
+        const apiRouter = express.Router();
+
+        apiRouter.get('/users/:userId/posts', (req, res) => {
+            const fields = String(req.query.fields || '').split(',');
+            const limit = Number(req.query.limit) || 0;
+            const items = [];
+            for (let i = 0; i < limit; i++) {
+                items.push({ id: i, title: `post ${i}`, author: req.params.userId });
+            }
+
+            res.json({
+                userId: req.params.userId,
+                fields,
+                count: items.length,
+                items
+            });
+        });
+
+        app.use('/api', apiRouter);
+    }
+};

--- a/benchmark/scenarios/body-json-4kb.js
+++ b/benchmark/scenarios/body-json-4kb.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// body-json-512kb is a stress case: at half a megabyte JSON.parse dominates and the framework is
+// about 1% of the request, so that row cannot move. A few KB is what an API actually receives, and
+// at that size the body plumbing around the parse is visible. Both rows are kept - one measures the
+// parser, this one measures getting the bytes to it.
+const PAD = 4 * 1024;
+
+module.exports = {
+    name: 'middlewares/body-json-4kb',
+    path: '/abc',
+    wrk: {
+        script: 'post-json-4kb.lua',
+        connections: 200
+    },
+    verify: {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ n: 1, pad: 'x'.repeat(PAD) })
+    },
+    setup(app, express) {
+        app.use(express.json());
+        app.post('/abc', (req, res) => {
+            res.send(`${req.body.pad.length}`);
+        });
+    }
+};

--- a/benchmark/scenarios/high-concurrency.js
+++ b/benchmark/scenarios/high-concurrency.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// Every other scenario runs at 50-200 connections, where connection handling is free. uWS's
+// advantage over node:http at high connection counts is structural - per-connection memory and
+// accept handling - rather than anything in the request path, and nothing in the suite exercised it.
+// The handler is deliberately trivial so the row measures connections and not work.
+//
+// Caveat: wrk shares the runner with the server, so at this connection count part of what is
+// measured is the generator. Two wrk threads on a 4 vCPU runner leaves the server two.
+module.exports = {
+    name: 'connections/high-concurrency',
+    path: '/ping',
+    wrk: {
+        threads: 2,
+        connections: 1000
+    },
+    setup(app) {
+        app.get('/ping', (req, res) => res.send('pong'));
+    }
+};

--- a/benchmark/scenarios/realistic-stack.js
+++ b/benchmark/scenarios/realistic-stack.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const helmet = require('helmet');
+const cors = require('cors');
+const cookieParser = require('cookie-parser');
+const morgan = require('morgan');
+
+// middlewares-100 measures 100 no-ops, which no application runs. This is the stack a typical
+// Express service actually mounts, at the depth it actually mounts it.
+// morgan writes to a sink rather than stdout so the row measures the formatting work every request
+// pays, not the runner's terminal. 'combined' is used because that is the production default, and
+// it includes the remote address, which both frameworks have to resolve their own way.
+module.exports = {
+    name: 'middlewares/realistic-stack',
+    path: '/profile',
+    wrk: {
+        script: 'realistic-stack.lua',
+        connections: 200
+    },
+    // keep these in sync with realistic-stack.lua: the verify request and the load request are
+    // separate definitions, so cors would otherwise be exercised only by one of them
+    verify: {
+        method: 'GET',
+        headers: {
+            'Cookie': 'sid=abc123; theme=dark',
+            'Origin': 'https://example.com'
+        }
+    },
+    setup(app, express) {
+        app.use(helmet());
+        app.use(cors());
+        app.use(cookieParser());
+        app.use(express.json());
+        app.use(morgan('combined', { stream: { write: () => {} } }));
+
+        app.get('/profile', (req, res) => {
+            res.json({
+                sid: req.cookies.sid || null,
+                theme: req.cookies.theme || null
+            });
+        });
+    }
+};

--- a/benchmark/wrk-scripts/post-json-4kb.lua
+++ b/benchmark/wrk-scripts/post-json-4kb.lua
@@ -1,0 +1,7 @@
+wrk.method = "POST"
+wrk.path = "/abc"
+wrk.headers["Content-Type"] = "application/json"
+
+local kb = 1024
+local pad = string.rep("x", 4 * kb)
+wrk.body = '{"n":1,"pad":"' .. pad .. '"}'

--- a/benchmark/wrk-scripts/realistic-stack.lua
+++ b/benchmark/wrk-scripts/realistic-stack.lua
@@ -1,0 +1,4 @@
+wrk.method = "GET"
+wrk.path = "/profile"
+wrk.headers["Cookie"] = "sid=abc123; theme=dark"
+wrk.headers["Origin"] = "https://example.com"


### PR DESCRIPTION
The three most common things an Express application does were not measured at all. Meanwhile five of the twelve rows sit on workloads dominated by `node:zlib`, `node:sha256`, `JSON.parse` or loopback bandwidth, where the ratio is capped by arithmetic, roughly 1.01x for the streaming rows and 1.02x for the 512 KiB JSON one, no matter what either framework does. The table currently reads as "these frameworks are mostly equivalent", when what it mostly measures is work neither of them performs.

This adds four rows for shapes that were missing, chosen for how common they are rather than for how they score.

### `routing/api-endpoint`

`GET /api/users/:userId/posts?fields=id,title,author&limit=10` through a mounted router, answering with `res.json()`. Param extraction, query parsing and serialisation, the shape where the framework's own work is a real share of the request rather than a rounding error.

### `middlewares/realistic-stack`

helmet + cors + cookie-parser + `express.json()` + morgan, which is what a service actually mounts, as opposed to `middlewares-100`'s hundred no-ops. morgan writes to a sink so the row measures the formatting every request pays rather than the runner's terminal, and `combined` is used because that is the production default, it includes the remote address, which each framework resolves its own way.

Worth saying plainly: **this row is not favourable, and that is the point.** Locally it comes out at 1.12x, because helmet, cors, cookie-parser and morgan are the same code on both sides. A realistic middleware stack is largely shared work, the same way zlib is. It is the row most relevant to somebody deciding whether to adopt, and it should say what it says.

### `middlewares/body-json-4kb`

A body-parser row at a size an API actually receives. The 512 KiB one is kept as the stress case, that one measures `JSON.parse`, this one measures getting the bytes to it.

### `connections/high-concurrency`

1000 connections against a trivial handler. Every other scenario runs at 50–200, where connection handling is free, so nothing in the suite exercised the part where uWS differs from `node:http` structurally rather than in the request path. Two wrk threads on a 4 vCPU runner leaves the server two; at this connection count some of what is measured is the generator, and the comment in the scenario says so.

---

<!-- benchmark-comment -->
## Benchmark Comparison

| Test | Express req/sec | uExpress req/sec | Express throughput | uExpress throughput | uExpress speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| connections/high-concurrency | 14.04k | 40.00k | 2.22 MB/sec | 6.37 MB/sec | **2.87x** |
| engines/art | 5.46k | 7.21k | 2.39 MB/sec | 3.17 MB/sec | **1.33x** |
| middlewares/body-json-4kb | 9.57k | 14.69k | 1.52 MB/sec | 2.34 MB/sec | **1.54x** |
| middlewares/body-json-512kb | 897.18 | 953.04 | 147.19 KB/sec | 157.29 KB/sec | **1.07x** |
| middlewares/body-urlencoded | 10.07k | 17.73k | 1.56 MB/sec | 2.77 MB/sec | **1.78x** |
| middlewares/compression-file | 6.64k | 6.92k | 3.03 MB/sec | 3.16 MB/sec | **1.04x** |
| middlewares/express-static | 2.83k | 5.10k | 691.69 MB/sec | 1.22 GB/sec | **1.81x** |
| middlewares/realistic-stack | 9.23k | 11.27k | 7.88 MB/sec | 9.64 MB/sec | **1.22x** |
| routing/api-endpoint | 10.92k | 26.19k | 6.66 MB/sec | 16.01 MB/sec | **2.40x** |
| routing/hello-world | 15.14k | 58.29k | 2.51 MB/sec | 9.73 MB/sec | **3.88x** |
| routing/middlewares-100 | 17.20k | 11.95k | 2.69 MB/sec | 1.88 MB/sec | **0.70x** |
| routing/nested-routers | 14.31k | 47.95k | 2.29 MB/sec | 7.73 MB/sec | **3.38x** |
| routing/routes-1000 | 4.77k | 36.39k | 764.59 KB/sec | 5.73 MB/sec | **7.67x** |
| streaming/readable-hash-4mb | 223.53 | 249.94 | 49.77 KB/sec | 55.90 KB/sec | **1.12x** |
| streaming/writable-no-content-length | 539.81 | 560.64 | 2.64 GB/sec | 2.74 GB/sec | **1.04x** |
| streaming/writable-with-content-length | 537.62 | 573.95 | 2.63 GB/sec | 2.81 GB/sec | **1.07x** |


