### PR TITLE
perf: stop copying request bodies twice

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -23,6 +23,11 @@ const querystring = require('fast-querystring');
 const { AsyncResource } = require('async_hooks');
 const { fastQueryParse, NullObject } = require('./utils.js');
 
+// largest content-length we will allocate a body buffer for up front. above this the body is
+// collected chunk by chunk instead, so a declared-but-unsent body cannot pin more memory than a
+// real one of the same size would
+const MAX_PREALLOCATED_BODY = 1024 * 1024;
+
 function static(root, options) {
     if(!options) options = new NullObject();
     if(typeof options.index === 'undefined') options.index = 'index.html';
@@ -232,6 +237,19 @@ function createBodyParser(defaultType, beforeReturn) {
                 }
             }
 
+            // uWS neuters its ArrayBuffer after the callback, so every chunk has to be copied out of
+            // it - and then Buffer.concat copied the whole body a second time. when content-length is
+            // known and we aren't inflating, the final size is known up front, so chunks can go
+            // straight into one buffer and the body is copied once.
+            // the cap means a client that declares a body and never sends it costs no more than one
+            // that actually sends a body that size, and content-length above options.limit was
+            // already rejected above
+            const declaredLength = inflate ? -1 : Number(length);
+            let target = declaredLength > 0 && declaredLength <= MAX_PREALLOCATED_BODY
+                ? Buffer.allocUnsafe(declaredLength)
+                : null;
+            let targetOffset = 0;
+
             req.bodyRead = true;
 
             // uWS keeps delivering chunks after we reject an oversized body, and the
@@ -250,15 +268,27 @@ function createBodyParser(defaultType, beforeReturn) {
                     buf = inflate.process(buf);
                 }
 
-                // shallow copy, to avoid shared references for large bodies.
-                abs.push(Buffer.from(buf));
-
                 totalSize += buf.length;
                 if(totalSize > options.limit) {
                     finished = true;
                     abs.length = 0;
+                    target = null;
                     return next(new Error('Request entity too large'));
                 }
+
+                if(target) {
+                    if(targetOffset + buf.length <= target.length) {
+                        buf.copy(target, targetOffset);
+                        targetOffset += buf.length;
+                        return;
+                    }
+                    // more body than content-length promised: keep what we have and fall back
+                    abs.push(Buffer.from(target.subarray(0, targetOffset)));
+                    target = null;
+                }
+
+                // shallow copy, to avoid shared references for large bodies.
+                abs.push(Buffer.from(buf));
             }
 
             function onEnd() {
@@ -266,7 +296,11 @@ function createBodyParser(defaultType, beforeReturn) {
                     return;
                 }
                 finished = true;
-                const buf = Buffer.concat(abs);
+                // target holds the whole body already; otherwise a single chunk is the body, and
+                // only a genuinely chunked body needs the concat
+                const buf = target
+                    ? (targetOffset === target.length ? target : target.subarray(0, targetOffset))
+                    : (abs.length === 1 ? abs[0] : Buffer.concat(abs));
                 if(options.verify) {
                     try {
                         options.verify(req, res, buf);

--- a/tests/tests/middlewares/body-collection-paths.js
+++ b/tests/tests/middlewares/body-collection-paths.js
@@ -1,0 +1,78 @@
+// must parse bodies identically whether they arrive in one chunk, many chunks, or compressed
+
+const express = require("express");
+const zlib = require("zlib");
+const crypto = require("crypto");
+
+const app = express();
+
+app.use(express.json({ limit: '8mb' }));
+app.use(express.raw({ limit: '8mb', type: 'application/octet-stream' }));
+
+app.post('/json', (req, res) => {
+    res.json({ len: req.body.pad.length, n: req.body.n });
+});
+
+app.post('/raw', (req, res) => {
+    res.json({
+        len: req.body.length,
+        sha: crypto.createHash('sha256').update(req.body).digest('hex').slice(0, 16)
+    });
+});
+
+function post(path, body, headers = {}) {
+    return fetch(`http://localhost:13333${path}`, { method: 'POST', body, headers });
+}
+
+app.listen(13333, async () => {
+    console.log('Server is running on port 13333');
+
+    // small enough to arrive in a single chunk, with a content-length
+    const small = JSON.stringify({ n: 1, pad: 'x'.repeat(4 * 1024) });
+    console.log(await (await post('/json', small, { 'Content-Type': 'application/json' })).text());
+
+    // large enough to arrive in several chunks, still with a content-length
+    const big = JSON.stringify({ n: 2, pad: 'y'.repeat(512 * 1024) });
+    console.log(await (await post('/json', big, { 'Content-Type': 'application/json' })).text());
+
+    // past the point where the body is buffered up front, so it is collected chunk by chunk
+    const huge = JSON.stringify({ n: 3, pad: 'z'.repeat(2 * 1024 * 1024) });
+    console.log(await (await post('/json', huge, { 'Content-Type': 'application/json' })).text());
+
+    // no content-length at all: the size is only known once the stream ends
+    const chunked = new ReadableStream({
+        start(controller) {
+            const enc = new TextEncoder();
+            controller.enqueue(enc.encode('{"n":4,"pad":"'));
+            for (let i = 0; i < 8; i++) {
+                controller.enqueue(enc.encode('w'.repeat(32 * 1024)));
+            }
+            controller.enqueue(enc.encode('"}'));
+            controller.close();
+        }
+    });
+    const chunkedResponse = await fetch('http://localhost:13333/json', {
+        method: 'POST',
+        body: chunked,
+        duplex: 'half',
+        headers: { 'Content-Type': 'application/json' }
+    });
+    console.log(await chunkedResponse.text());
+
+    // gzipped: content-length describes the compressed size, not the parsed one
+    const gzipped = zlib.gzipSync(Buffer.from(JSON.stringify({ n: 5, pad: 'q'.repeat(256 * 1024) })));
+    console.log(await (await post('/json', gzipped, {
+        'Content-Type': 'application/json',
+        'Content-Encoding': 'gzip'
+    })).text());
+
+    // binary round trip, to catch a body that is assembled at the wrong offset
+    const binary = Buffer.alloc(300 * 1024);
+    for (let i = 0; i < binary.length; i++) {
+        binary[i] = i % 251;
+    }
+    console.log(await (await post('/raw', binary, { 'Content-Type': 'application/octet-stream' })).text());
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+    process.exit(0);
+});


### PR DESCRIPTION
Every request body is currently copied twice before it reaches the parser.

uWS neuters its `ArrayBuffer` once the data callback returns, so each chunk has to be copied out of it `abs.push(Buffer.from(buf))` in `onData`. Then `onEnd` calls `Buffer.concat(abs)`, which allocates the full body again and copies all of it a second time. A 512 KiB request means two 512 KiB allocations and two full memcpys, plus one allocation per chunk for the garbage collector to deal with.

## What changed

When `content-length` is known and the body is not being inflated, the final size is known before the first chunk arrives. The chunks are copied straight into one preallocated buffer at the right offset, and `onEnd` returns it as-is. One copy instead of two, and no per-chunk garbage.

Three cases keep the previous path:

- **no `content-length`**: a chunked body's size is only known at the end
- **`content-encoding` set**: `content-length` describes the compressed size, not the parsed one
- **bodies above the preallocation cap**: see below

That path also got a small fix of its own: when the whole body arrived in a single chunk, which is the common case for small requests, the copy already made *is* the body, so the concat is skipped.

## On the cap

`MAX_PREALLOCATED_BODY` is 1 MiB. Without a cap, a client could declare a large `content-length`, send one byte, and make the server allocate the whole declared size, today that costs it almost nothing. With the cap, a client that declares a body and never sends it cannot pin more memory than one that actually sends a body that size, which it could do anyway. A `content-length` above `options.limit` is already rejected before any of this, so the preallocation is also bounded by whatever the application configured.

## Measurements

Local A/B, baseline `src` against modified `src` on the same machine, 5 paired runs, median of per-run ratios:

| body size | baseline | this branch | paired ratio | favourable runs |
| ---: | ---: | ---: | ---: | ---: |
| 4 KiB | 6217 req/sec | 6788 req/sec | 1.092 | 4/5 |
| 64 KiB | 2661 req/sec | 2980 req/sec | 1.104 | 3/5 |
| 512 KiB | 519 req/sec | 595 req/sec | **1.146** | **5/5** |

The 512 KiB row is the one to trust: all five pairs favour the change and they sit in a narrow band, 1.08–1.18. At the smaller sizes the gain is real but close to this machine's noise floor of about ±6%, so read those as directional.

`middlewares/body-json-512kb` on CI is one of the rows bounded by `JSON.parse`, the arithmetic ceiling there is around 1.02x on the ratio against express, because express pays the same parse. This does not change that. What it changes is uExpress's own absolute number, which is what the local A/B measures.

## Unrelated thing found while writing the test

With `express.raw()` and an empty body, express sets `req.body` to an empty Buffer while uExpress leaves it as the default empty object, so `crypto.createHash().update(req.body)` throws on uExpress and works on express. It reproduces on `main` without this branch, `type-is` reports no body at `content-length: 0`, so the parser returns early and never assigns. Not touched here; worth a separate look.
