### PR TITLE
test: fix running a single test file by path on Windows

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -21,7 +21,10 @@ if(filterPath) {
     if(!filterPath.endsWith('.js')) {
         testCategories = testCategories.filter(category => category.startsWith(path.basename(filterPath)));
     } else {
-        testCategories = [path.dirname(filterPath).split(path.sep).pop()];
+        // basename, not split(path.sep): on Windows path.sep is a backslash, so a path typed with
+        // forward slashes never split and the whole "tests/tests/middlewares" came back as the
+        // category name. path.basename handles either separator on both platforms
+        testCategories = [path.basename(path.dirname(filterPath))];
     }
 }
 


### PR DESCRIPTION
Running one test file by path, the way the usage comment at the top of `tests/index.js` documents it:

```
$ node tests/index.js tests/tests/middlewares/body-limit-chunked.js

ENOENT: no such file or directory, scandir
'...\ultimate-express\tests\tests\tests\tests\middlewares'
```

The category was derived with `path.dirname(filterPath).split(path.sep).pop()`. On Windows `path.sep` is a backslash, so a path typed with forward slashes never split `path.dirname` returned `tests/tests/middlewares`, `split('\')` produced a single element, and `pop()` handed back the whole thing as the category name. It was then joined onto the tests directory again, hence the doubled path.

`path.basename(path.dirname(filterPath))` handles either separator on both platforms.

Verified on Windows with all four forms forward slashes, backslashes, a leading `./`, and a bare filename and by running the same file both ways and confirming it selects one test rather than the whole category.
