### PR TITLE
fix: give an empty request body the shape express gives it

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -181,10 +181,6 @@ function createBodyParser(defaultType, beforeReturn) {
             }
 
             const length = req.headers['content-length'];
-            // skip reading empty body
-            if(length == '0') {
-                return next();
-            }
 
             if(options.simpleType) {
                 const semicolonIndex = type.indexOf(';');
@@ -202,6 +198,13 @@ function createBodyParser(defaultType, beforeReturn) {
                         return next();
                     }
                 }
+            }
+
+            // an empty body still has to produce this parser's empty value the way express does -
+            // {} for json and urlencoded, '' for text, an empty Buffer for raw - rather than leaving
+            // req.body as the placeholder object. there is nothing to read, so run the tail directly
+            if(length == '0') {
+                return beforeReturn(req, res, next, options, Buffer.alloc(0));
             }
 
             // skip reading too large body

--- a/tests/tests/middlewares/empty-body-parsers.js
+++ b/tests/tests/middlewares/empty-body-parsers.js
@@ -1,0 +1,49 @@
+// must give an empty body the same shape express does, for every body parser
+
+const express = require("express");
+
+const app = express();
+
+app.post('/json', express.json(), (req, res) => {
+    res.json({ type: typeof req.body, isBuffer: Buffer.isBuffer(req.body), value: JSON.stringify(req.body) });
+});
+
+app.post('/urlencoded', express.urlencoded({ extended: false }), (req, res) => {
+    res.json({ type: typeof req.body, keys: Object.keys(req.body).length });
+});
+
+app.post('/text', express.text(), (req, res) => {
+    res.json({ type: typeof req.body, length: req.body.length });
+});
+
+app.post('/raw', express.raw(), (req, res) => {
+    res.json({ isBuffer: Buffer.isBuffer(req.body), length: req.body.length });
+});
+
+function empty(path, contentType) {
+    return fetch(`http://localhost:13333${path}`, {
+        method: 'POST',
+        body: '',
+        headers: { 'Content-Type': contentType }
+    }).then(r => r.text());
+}
+
+app.listen(13333, async () => {
+    console.log('Server is running on port 13333');
+
+    console.log(await empty('/json', 'application/json'));
+    console.log(await empty('/urlencoded', 'application/x-www-form-urlencoded'));
+    console.log(await empty('/text', 'text/plain'));
+    console.log(await empty('/raw', 'application/octet-stream'));
+
+    // a non-empty body must still parse the same way afterwards
+    const after = await fetch('http://localhost:13333/json', {
+        method: 'POST',
+        body: '{"a":1}',
+        headers: { 'Content-Type': 'application/json' }
+    });
+    console.log(await after.text());
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+    process.exit(0);
+});


### PR DESCRIPTION
A request with `content-length: 0` returned early before any parser ran, leaving `req.body` as the placeholder object every parser starts from. Express runs the parser regardless, and each one produces its own empty value.

```js
app.post('/upload', express.raw(), (req, res) => {
    hash.update(req.body);   // Buffer on express, plain object here -> throws
});
```

Same for `express.text()`, where express hands back `''` and this handed back an object.

| parser | express 4 | express 5 | uExpress before | uExpress after |
| --- | --- | --- | --- | --- |
| `json` | `{}` | `{}` | `{}` | `{}` |
| `urlencoded` | `{}` | `{}` | `{}` | `{}` |
| `text` | `''` | `''` | `{}` | `''` |
| `raw` | empty `Buffer` | empty `Buffer` | `{}` | empty `Buffer` |

`json` and `urlencoded` happened to line up because the placeholder is object-shaped; `text` and `raw` did not.

## What changed

The empty case now runs the parser tail directly with an empty buffer instead of returning early, and it does so **after** the content-type checks, so a parser still ignores a request it does not handle. Nothing is read, so the cost is one zero-length buffer allocation on a path that previously did nothing.

All four tails already handled an empty buffer — `json` even has an explicit `if(buf.length === 0)` branch — so each one produces what it should without further changes.

## One thing deliberately left alone

When a parser does *not* claim a request, express 4 leaves `req.body` as `{}` and express 5 leaves it `undefined`. uExpress follows express 4, which is what the suite enforces. That divergence predates this change and is not touched here — the test avoids that case so it can pass cleanly against both express versions.
